### PR TITLE
탭 관련 도메인 추가

### DIFF
--- a/src/main/java/com/management/tab/domain/common/AuditTimestamps.java
+++ b/src/main/java/com/management/tab/domain/common/AuditTimestamps.java
@@ -1,0 +1,30 @@
+package com.management.tab.domain.common;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@EqualsAndHashCode
+public class AuditTimestamps {
+
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static AuditTimestamps now() {
+        LocalDateTime now = LocalDateTime.now();
+
+        return new AuditTimestamps(now, now);
+    }
+
+    public AuditTimestamps updateTimestamp() {
+        return new AuditTimestamps(this.createdAt, LocalDateTime.now());
+    }
+
+    private AuditTimestamps(LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}
+

--- a/src/main/java/com/management/tab/domain/tab/Tab.java
+++ b/src/main/java/com/management/tab/domain/tab/Tab.java
@@ -1,0 +1,91 @@
+package com.management.tab.domain.tab;
+
+import com.management.tab.domain.common.AuditTimestamps;
+import com.management.tab.domain.tab.vo.GroupId;
+import com.management.tab.domain.tab.vo.TabId;
+import com.management.tab.domain.tab.vo.TabPosition;
+import com.management.tab.domain.tab.vo.TabTitle;
+import com.management.tab.domain.tab.vo.TabUrl;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@EqualsAndHashCode(of = {"id"})
+public class Tab {
+
+    private final TabId id;
+    private final TabId parentId;
+    private final GroupId groupId;
+    private final TabTitle title;
+    private final TabUrl url;
+    private final TabPosition position;
+    private final AuditTimestamps timestamps;
+
+    Tab(
+            TabId id,
+            TabId parentId,
+            GroupId groupId,
+            TabTitle title,
+            TabUrl url,
+            TabPosition position,
+            AuditTimestamps timestamps
+    ) {
+        this.id = id;
+        this.parentId = parentId;
+        this.groupId = groupId;
+        this.title = title;
+        this.url = url;
+        this.position = position;
+        this.timestamps = timestamps;
+    }
+
+    public Tab updateInfo(String newTitle, String newUrl) {
+        return new Tab(
+                this.id,
+                this.parentId,
+                this.groupId,
+                TabTitle.create(newTitle),
+                TabUrl.create(newUrl),
+                this.position,
+                this.timestamps.updateTimestamp()
+        );
+    }
+
+    public Tab updatePosition(int newPosition) {
+        return new Tab(
+                this.id,
+                this.parentId,
+                this.groupId,
+                this.title,
+                this.url,
+                TabPosition.create(newPosition),
+                this.timestamps.updateTimestamp()
+        );
+    }
+
+    public Tab moveTo(TabId newParentId, int newPosition) {
+        return new Tab(
+                this.id,
+                newParentId,
+                this.groupId,
+                this.title,
+                this.url,
+                TabPosition.create(newPosition),
+                this.timestamps.updateTimestamp()
+        );
+    }
+
+    public boolean isRoot() {
+        return parentId == null;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return timestamps.getCreatedAt();
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return timestamps.getUpdatedAt();
+    }
+}

--- a/src/main/java/com/management/tab/domain/tab/TabBuilder.java
+++ b/src/main/java/com/management/tab/domain/tab/TabBuilder.java
@@ -1,0 +1,120 @@
+package com.management.tab.domain.tab;
+
+import com.management.tab.domain.common.AuditTimestamps;
+import com.management.tab.domain.tab.vo.GroupId;
+import com.management.tab.domain.tab.vo.TabId;
+import com.management.tab.domain.tab.vo.TabPosition;
+import com.management.tab.domain.tab.vo.TabTitle;
+import com.management.tab.domain.tab.vo.TabUrl;
+import java.util.Objects;
+
+public class TabBuilder {
+
+    private TabId id;
+    private TabId parentId;
+    private GroupId groupId;
+    private TabTitle title;
+    private TabUrl url;
+    private TabPosition position;
+    private AuditTimestamps timestamps;
+
+    public static TabBuilder builder() {
+        return new TabBuilder();
+    }
+
+    public static TabBuilder createRoot(Long groupId, String title, String url) {
+        TabBuilder builder = new TabBuilder();
+
+        builder.groupId = GroupId.create(groupId);
+        builder.title = TabTitle.create(title);
+        builder.url = TabUrl.create(url);
+
+        return builder;
+    }
+
+    public static TabBuilder createChild(GroupId groupId, TabId parentId, String title, String url) {
+        validateParentId(parentId);
+
+        TabBuilder builder = new TabBuilder();
+
+        builder.groupId = groupId;
+        builder.parentId = parentId;
+
+        return builder.title(title)
+                      .url(url);
+    }
+
+    private static void validateParentId(TabId parentId) {
+        Objects.requireNonNull(parentId, "부모 ID는 필수입니다.");
+    }
+
+    public static TabBuilder createWithAssignedId(Long tabId, Tab tab) {
+        TabBuilder builder = new TabBuilder();
+
+        builder.id = TabId.create(tabId);
+        builder.parentId = tab.getParentId();
+        builder.groupId = tab.getGroupId();
+        builder.title = tab.getTitle();
+        builder.url = tab.getUrl();
+        builder.position = tab.getPosition();
+        builder.timestamps = tab.getTimestamps();
+
+        return builder;
+    }
+
+    private TabBuilder() {
+    }
+
+    public TabBuilder parentId(Long parentId) {
+        this.parentId = TabId.create(parentId);
+
+        return this;
+    }
+
+    public TabBuilder groupId(Long groupId) {
+        this.groupId = GroupId.create(groupId);
+
+        return this;
+    }
+
+    public TabBuilder title(String title) {
+        this.title = TabTitle.create(title);
+
+        return this;
+    }
+
+    public TabBuilder url(String url) {
+        this.url = TabUrl.create(url);
+
+        return this;
+    }
+
+    public TabBuilder position(int position) {
+        this.position = TabPosition.create(position);
+
+        return this;
+    }
+
+    public Tab build() {
+        validateValues();
+
+        TabPosition finalPosition = position != null ? position : TabPosition.defaultPosition();
+        AuditTimestamps auditTimestamps = timestamps != null ? timestamps : AuditTimestamps.now();
+
+        return new Tab(
+                id,
+                parentId,
+                groupId,
+                title,
+                url,
+                finalPosition,
+                auditTimestamps
+        );
+    }
+
+    private void validateValues() {
+        Objects.requireNonNull(groupId, "그룹 ID는 필수입니다.");
+        Objects.requireNonNull(title, "제목은 필수입니다.");
+        Objects.requireNonNull(url, "Url은 필수입니다.");
+    }
+}

--- a/src/main/java/com/management/tab/domain/tab/vo/GroupId.java
+++ b/src/main/java/com/management/tab/domain/tab/vo/GroupId.java
@@ -1,0 +1,27 @@
+package com.management.tab.domain.tab.vo;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class GroupId {
+
+    private final Long value;
+
+    public static GroupId create(Long value) {
+        validateValue(value);
+
+        return new GroupId(value);
+    }
+
+    private static void validateValue(Long value) {
+        if (value == null || value <= 0) {
+            throw new IllegalArgumentException("GroupId는 양수여야 합니다");
+        }
+    }
+
+    private GroupId(Long value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/management/tab/domain/tab/vo/TabId.java
+++ b/src/main/java/com/management/tab/domain/tab/vo/TabId.java
@@ -1,0 +1,32 @@
+package com.management.tab.domain.tab.vo;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class TabId {
+
+    private final Long value;
+
+    public static TabId create(Long value) {
+        validateValue(value);
+
+        return new TabId(value);
+    }
+
+    private static void validateValue(Long value) {
+        if (value == null || value <= 0) {
+            throw new IllegalArgumentException("TabId는 양수여야 합니다.");
+        }
+    }
+
+    private TabId(Long value) {
+        this.value = value;
+    }
+
+    public Long id() {
+        return value;
+    }
+}
+

--- a/src/main/java/com/management/tab/domain/tab/vo/TabPosition.java
+++ b/src/main/java/com/management/tab/domain/tab/vo/TabPosition.java
@@ -1,0 +1,39 @@
+package com.management.tab.domain.tab.vo;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class TabPosition {
+
+    private final Integer value;
+
+    public static TabPosition defaultPosition() {
+        return new TabPosition(0);
+    }
+
+    public TabPosition next() {
+        return new TabPosition(value + 1);
+    }
+
+    public static TabPosition create(int value) {
+        validateValue(value);
+
+        return new TabPosition(value);
+    }
+
+    private static void validateValue(int value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("위치는 0 이상이어야 합니다");
+        }
+    }
+
+    private TabPosition(Integer value) {
+        this.value = value;
+    }
+
+    public boolean isFirst() {
+        return value == 0;
+    }
+}

--- a/src/main/java/com/management/tab/domain/tab/vo/TabTitle.java
+++ b/src/main/java/com/management/tab/domain/tab/vo/TabTitle.java
@@ -1,0 +1,33 @@
+package com.management.tab.domain.tab.vo;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class TabTitle {
+
+    private static final int MAX_LENGTH = 50;
+
+    private final String value;
+
+    public static TabTitle create(String value) {
+        validateValue(value);
+
+        return new TabTitle(value);
+    }
+
+    private static void validateValue(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("탭 제목은 비어있을 수 없습니다.");
+        }
+
+        if (value.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("탭 제목은 " + MAX_LENGTH + "자를 초과할 수 없습니다.");
+        }
+    }
+
+    private TabTitle(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/management/tab/domain/tab/vo/TabUrl.java
+++ b/src/main/java/com/management/tab/domain/tab/vo/TabUrl.java
@@ -1,0 +1,36 @@
+package com.management.tab.domain.tab.vo;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.regex.Pattern;
+
+@Getter
+@EqualsAndHashCode
+public class TabUrl {
+
+    private static final Pattern URL_PATTERN = Pattern.compile(
+            "^https?://(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b[-a-zA-Z0-9()@:%_\\+.~#?&/=]*$"
+    );
+
+    private final String value;
+
+    public static TabUrl create(String value) {
+        validateValue(value);
+        return new TabUrl(value);
+    }
+
+    private static void validateValue(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("탭 URL은 비어있을 수 없습니다");
+        }
+
+        if (!URL_PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException("유효한 URL 형식이 아닙니다");
+        }
+    }
+
+    private TabUrl(String value) {
+        this.value = value;
+    }
+}

--- a/src/test/java/com/management/tab/domain/common/AuditTimestampsTest.java
+++ b/src/test/java/com/management/tab/domain/common/AuditTimestampsTest.java
@@ -1,0 +1,97 @@
+package com.management.tab.domain.common;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AuditTimestampsTest {
+
+    @Test
+    void 생성시각과_수정시각이_같은_AuditTimestamps를_초기화한다() {
+        // when
+        AuditTimestamps timestamps = AuditTimestamps.now();
+
+        // then
+        assertAll(
+                () -> assertThat(timestamps).isNotNull(),
+                () -> assertThat(timestamps.getCreatedAt()).isNotNull(),
+                () -> assertThat(timestamps.getUpdatedAt()).isNotNull(),
+                () -> assertThat(timestamps.getCreatedAt()).isEqualTo(timestamps.getUpdatedAt())
+        );
+    }
+
+    @Test
+    void 생성시각은_유지되고_수정시각만_변경해_새로운_AuditTimestamps를_초기화한다() throws InterruptedException {
+        // given
+        AuditTimestamps original = AuditTimestamps.now();
+        LocalDateTime originalCreatedAt = original.getCreatedAt();
+        LocalDateTime originalUpdatedAt = original.getUpdatedAt();
+
+        Thread.sleep(10);
+
+        // when
+        AuditTimestamps updated = original.updateTimestamp();
+
+        // then
+        assertAll(
+                () -> assertThat(updated.getCreatedAt()).isEqualTo(originalCreatedAt),
+                () -> assertThat(updated.getUpdatedAt()).isAfter(originalUpdatedAt),
+                () -> assertThat(updated.getCreatedAt()).isBefore(updated.getUpdatedAt())
+        );
+    }
+
+    @Test
+    void 같은_시각을_가진_AuditTimestamps는_동등하다() {
+        // given
+        AuditTimestamps timestamps1 = AuditTimestamps.now();
+
+        AuditTimestamps timestamps2 = timestamps1;
+
+        // when & then
+        assertAll(
+                () -> assertThat(timestamps1).isEqualTo(timestamps2),
+                () -> assertThat(timestamps1).hasSameHashCodeAs(timestamps2)
+        );
+    }
+
+    @Test
+    void 다른_시각을_가진_AuditTimestamps는_동등하지_않다() throws InterruptedException {
+        // given
+        AuditTimestamps timestamps1 = AuditTimestamps.now();
+
+        Thread.sleep(10);
+
+        AuditTimestamps timestamps2 = AuditTimestamps.now();
+
+        // when & then
+        assertAll(
+                () -> assertThat(timestamps1).isNotEqualTo(timestamps2),
+                () -> assertThat(timestamps1).doesNotHaveSameHashCodeAs(timestamps2)
+        );
+    }
+
+    @Test
+    void updateTimestamp_결과는_원본과_동등하지_않다() throws InterruptedException {
+        // given
+        AuditTimestamps original = AuditTimestamps.now();
+
+        Thread.sleep(10);
+
+        // when
+        AuditTimestamps updated = original.updateTimestamp();
+
+        // then
+        assertAll(
+                () -> assertThat(original).isNotEqualTo(updated),
+                () -> assertThat(original).doesNotHaveSameHashCodeAs(updated)
+        );
+    }
+}
+

--- a/src/test/java/com/management/tab/domain/tab/TabBuilderTest.java
+++ b/src/test/java/com/management/tab/domain/tab/TabBuilderTest.java
@@ -1,0 +1,371 @@
+package com.management.tab.domain.tab;
+
+import com.management.tab.domain.common.AuditTimestamps;
+import com.management.tab.domain.tab.vo.GroupId;
+import com.management.tab.domain.tab.vo.TabId;
+import com.management.tab.domain.tab.vo.TabPosition;
+import com.management.tab.domain.tab.vo.TabTitle;
+import com.management.tab.domain.tab.vo.TabUrl;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TabBuilderTest {
+
+    @Test
+    void builder로_빌더를_생성할_수_있다() {
+        // when
+        TabBuilder builder = TabBuilder.builder();
+
+        // then
+        assertThat(builder).isNotNull();
+    }
+
+    @Test
+    void createRoot로_루트_탭_빌더를_생성할_수_있다() {
+        // given
+        Long groupId = 1L;
+        String title = "루트 탭";
+        String url = "https://example.com";
+
+        // when
+        TabBuilder builder = TabBuilder.createRoot(groupId, title, url);
+
+        // then
+        assertThat(builder).isNotNull();
+    }
+
+    @Test
+    void createRoot로_생성한_빌더로_루트_탭을_build할_수_있다() {
+        // given
+        Long groupId = 1L;
+        String title = "루트 탭";
+        String url = "https://example.com";
+
+        // when
+        Tab tab = TabBuilder.createRoot(groupId, title, url)
+                            .position(0)
+                            .build();
+
+        // then
+        assertAll(
+                () -> assertThat(tab).isNotNull(),
+                () -> assertThat(tab.getGroupId().getValue()).isEqualTo(groupId),
+                () -> assertThat(tab.getTitle().getValue()).isEqualTo(title),
+                () -> assertThat(tab.getUrl().getValue()).isEqualTo(url),
+                () -> assertThat(tab.getParentId()).isNull(),
+                () -> assertThat(tab.isRoot()).isTrue()
+        );
+    }
+
+    @Test
+    void createChild로_자식_탭_빌더를_생성할_수_있다() {
+        // given
+        GroupId groupId = GroupId.create(1L);
+        TabId parentId = TabId.create(10L);
+        String title = "자식 탭";
+        String url = "https://child.com";
+
+        // when
+        TabBuilder builder = TabBuilder.createChild(groupId, parentId, title, url);
+
+        // then
+        assertThat(builder).isNotNull();
+    }
+
+    @Test
+    void createChild로_생성한_빌더로_자식_탭을_build할_수_있다() {
+        // given
+        GroupId groupId = GroupId.create(1L);
+        TabId parentId = TabId.create(10L);
+        String title = "자식 탭";
+        String url = "https://child.com";
+
+        // when
+        Tab tab = TabBuilder.createChild(groupId, parentId, title, url)
+                            .position(0)
+                            .build();
+
+        // then
+        assertAll(
+                () -> assertThat(tab).isNotNull(),
+                () -> assertThat(tab.getGroupId()).isEqualTo(groupId),
+                () -> assertThat(tab.getParentId()).isEqualTo(parentId),
+                () -> assertThat(tab.getTitle().getValue()).isEqualTo(title),
+                () -> assertThat(tab.getUrl().getValue()).isEqualTo(url),
+                () -> assertThat(tab.isRoot()).isFalse()
+        );
+    }
+
+    @Test
+    void createChild에서_parentId가_null이면_예외가_발생한다() {
+        // given
+        GroupId groupId = GroupId.create(1L);
+        TabId parentId = null;
+        String title = "자식 탭";
+        String url = "https://child.com";
+
+        // when & then
+        assertThatThrownBy(() -> TabBuilder.createChild(groupId, parentId, title, url))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("부모 ID는 필수입니다.");
+    }
+
+    @Test
+    void createWithAssignedId로_기존_Tab에서_ID를_할당한_빌더를_생성할_수_있다() {
+        // given
+        TabId tabId = TabId.create(1L);
+        TabId parentId = TabId.create(10L);
+        GroupId groupId = GroupId.create(100L);
+        TabTitle title = TabTitle.create("기존 탭");
+        TabUrl url = TabUrl.create("https://existing.com");
+        TabPosition position = TabPosition.create(0);
+        AuditTimestamps timestamps = AuditTimestamps.now();
+        Tab existingTab = new Tab(tabId, parentId, groupId, title, url, position, timestamps);
+
+        Long newTabId = 999L;
+
+        // when
+        Tab newTab = TabBuilder.createWithAssignedId(newTabId, existingTab).build();
+
+        // then
+        assertAll(
+                () -> assertThat(newTab).isNotNull(),
+                () -> assertThat(newTab.getId().getValue()).isEqualTo(newTabId),
+                () -> assertThat(newTab.getParentId()).isEqualTo(existingTab.getParentId()),
+                () -> assertThat(newTab.getGroupId()).isEqualTo(existingTab.getGroupId()),
+                () -> assertThat(newTab.getTitle()).isEqualTo(existingTab.getTitle()),
+                () -> assertThat(newTab.getUrl()).isEqualTo(existingTab.getUrl()),
+                () -> assertThat(newTab.getPosition()).isEqualTo(existingTab.getPosition()),
+                () -> assertThat(newTab.getTimestamps()).isEqualTo(existingTab.getTimestamps())
+        );
+    }
+
+    @Test
+    void parentId로_부모_ID를_설정할_수_있다() {
+        // given
+        Long parentIdValue = 10L;
+
+        // when
+        Tab tab = TabBuilder.builder()
+                            .parentId(parentIdValue)
+                            .groupId(1L)
+                            .title("테스트 탭")
+                            .url("https://test.com")
+                            .position(0)
+                            .build();
+
+        // then
+        assertThat(tab.getParentId().getValue()).isEqualTo(parentIdValue);
+    }
+
+    @Test
+    void groupId로_그룹_ID를_설정할_수_있다() {
+        // given
+        Long groupIdValue = 100L;
+
+        // when
+        Tab tab = TabBuilder.builder()
+                            .groupId(groupIdValue)
+                            .title("테스트 탭")
+                            .url("https://test.com")
+                            .position(0)
+                            .build();
+
+        // then
+        assertThat(tab.getGroupId().getValue()).isEqualTo(groupIdValue);
+    }
+
+    @Test
+    void title로_제목을_설정할_수_있다() {
+        // given
+        String titleValue = "테스트 제목";
+
+        // when
+        Tab tab = TabBuilder.builder()
+                            .groupId(1L)
+                            .title(titleValue)
+                            .url("https://test.com")
+                            .position(0)
+                            .build();
+
+        // then
+        assertThat(tab.getTitle().getValue()).isEqualTo(titleValue);
+    }
+
+    @Test
+    void url로_URL을_설정할_수_있다() {
+        // given
+        String urlValue = "https://example.com";
+
+        // when
+        Tab tab = TabBuilder.builder()
+                            .groupId(1L)
+                            .title("테스트 탭")
+                            .url(urlValue)
+                            .position(0)
+                            .build();
+
+        // then
+        assertThat(tab.getUrl().getValue()).isEqualTo(urlValue);
+    }
+
+    @Test
+    void position으로_위치를_설정할_수_있다() {
+        // given
+        int positionValue = 5;
+
+        // when
+        Tab tab = TabBuilder.builder()
+                            .groupId(1L)
+                            .title("테스트 탭")
+                            .url("https://test.com")
+                            .position(positionValue)
+                            .build();
+
+        // then
+        assertThat(tab.getPosition().getValue()).isEqualTo(positionValue);
+    }
+
+    @Test
+    void position을_설정하지_않으면_기본값이_설정된다() {
+        // when
+        Tab tab = TabBuilder.builder()
+                            .groupId(1L)
+                            .title("테스트 탭")
+                            .url("https://test.com")
+                            .build();
+
+        // then
+        assertThat(tab.getPosition()).isEqualTo(TabPosition.defaultPosition());
+    }
+
+    @Test
+    void timestamps를_설정하지_않으면_현재_시간이_설정된다() {
+        // when
+        Tab tab = TabBuilder.builder()
+                            .groupId(1L)
+                            .title("테스트 탭")
+                            .url("https://test.com")
+                            .position(0)
+                            .build();
+
+        // then
+        assertAll(
+                () -> assertThat(tab.getCreatedAt()).isNotNull(),
+                () -> assertThat(tab.getUpdatedAt()).isNotNull()
+        );
+    }
+
+    @Test
+    void groupId가_없으면_build_시_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> TabBuilder.builder()
+                                           .title("테스트 탭")
+                                           .url("https://test.com")
+                                           .position(0)
+                                           .build())
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("그룹 ID는 필수입니다.");
+    }
+
+    @Test
+    void title이_없으면_build_시_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> TabBuilder.builder()
+                                           .groupId(1L)
+                                           .url("https://test.com")
+                                           .position(0)
+                                           .build())
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("제목은 필수입니다.");
+    }
+
+    @Test
+    void url이_없으면_build_시_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> TabBuilder.builder()
+                                           .groupId(1L)
+                                           .title("테스트 탭")
+                                           .position(0)
+                                           .build())
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Url은 필수입니다.");
+    }
+
+    @Test
+    void 메서드_체이닝으로_Tab을_생성할_수_있다() {
+        // given
+        Long parentIdValue = 10L;
+        Long groupIdValue = 100L;
+        String titleValue = "체이닝 테스트";
+        String urlValue = "https://chaining.com";
+        int positionValue = 3;
+
+        // when
+        Tab tab = TabBuilder.builder()
+                            .parentId(parentIdValue)
+                            .groupId(groupIdValue)
+                            .title(titleValue)
+                            .url(urlValue)
+                            .position(positionValue)
+                            .build();
+
+        // then
+        assertAll(
+                () -> assertThat(tab).isNotNull(),
+                () -> assertThat(tab.getParentId().getValue()).isEqualTo(parentIdValue),
+                () -> assertThat(tab.getGroupId().getValue()).isEqualTo(groupIdValue),
+                () -> assertThat(tab.getTitle().getValue()).isEqualTo(titleValue),
+                () -> assertThat(tab.getUrl().getValue()).isEqualTo(urlValue),
+                () -> assertThat(tab.getPosition().getValue()).isEqualTo(positionValue)
+        );
+    }
+
+    @Test
+    void createRoot는_parentId_없이_Tab을_생성한다() {
+        // given
+        Long groupId = 1L;
+        String title = "루트 탭";
+        String url = "https://root.com";
+
+        // when
+        Tab tab = TabBuilder.createRoot(groupId, title, url)
+                            .position(0)
+                            .build();
+
+        // then
+        assertAll(
+                () -> assertThat(tab.getParentId()).isNull(),
+                () -> assertThat(tab.isRoot()).isTrue()
+        );
+    }
+
+    @Test
+    void createRoot_이후_parentId를_설정하면_자식_탭으로_변경할_수_있다() {
+        // given
+        Long groupId = 1L;
+        String title = "루트에서 자식으로";
+        String url = "https://change.com";
+        Long parentIdValue = 10L;
+
+        // when
+        Tab tab = TabBuilder.createRoot(groupId, title, url)
+                            .parentId(parentIdValue)
+                            .position(0)
+                            .build();
+
+        // then
+        assertAll(
+                () -> assertThat(tab.getParentId()).isNotNull(),
+                () -> assertThat(tab.getParentId().getValue()).isEqualTo(parentIdValue),
+                () -> assertThat(tab.isRoot()).isFalse()
+        );
+    }
+}

--- a/src/test/java/com/management/tab/domain/tab/TabTest.java
+++ b/src/test/java/com/management/tab/domain/tab/TabTest.java
@@ -1,0 +1,266 @@
+package com.management.tab.domain.tab;
+
+import com.management.tab.domain.common.AuditTimestamps;
+import com.management.tab.domain.tab.vo.GroupId;
+import com.management.tab.domain.tab.vo.TabId;
+import com.management.tab.domain.tab.vo.TabPosition;
+import com.management.tab.domain.tab.vo.TabTitle;
+import com.management.tab.domain.tab.vo.TabUrl;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TabTest {
+
+    @Test
+    void Tab을_생성할_수_있다() {
+        // given
+        TabId tabId = TabId.create(1L);
+        TabId parentId = TabId.create(10L);
+        GroupId groupId = GroupId.create(100L);
+        TabTitle title = TabTitle.create("테스트 탭");
+        TabUrl url = TabUrl.create("https://example.com");
+        TabPosition position = TabPosition.create(0);
+        AuditTimestamps timestamps = AuditTimestamps.now();
+
+        // when
+        Tab tab = new Tab(tabId, parentId, groupId, title, url, position, timestamps);
+
+        // then
+        assertAll(
+                () -> assertThat(tab).isNotNull(),
+                () -> assertThat(tab.getId()).isEqualTo(tabId),
+                () -> assertThat(tab.getParentId()).isEqualTo(parentId),
+                () -> assertThat(tab.getGroupId()).isEqualTo(groupId),
+                () -> assertThat(tab.getTitle()).isEqualTo(title),
+                () -> assertThat(tab.getUrl()).isEqualTo(url),
+                () -> assertThat(tab.getPosition()).isEqualTo(position),
+                () -> assertThat(tab.getTimestamps()).isEqualTo(timestamps)
+        );
+    }
+
+    @Test
+    void updateInfo로_제목과_URL을_업데이트할_수_있다() {
+        // given
+        TabId tabId = TabId.create(1L);
+        TabId parentId = TabId.create(10L);
+        GroupId groupId = GroupId.create(100L);
+        TabTitle title = TabTitle.create("테스트 탭");
+        TabUrl url = TabUrl.create("https://example.com");
+        TabPosition position = TabPosition.create(0);
+        AuditTimestamps timestamps = AuditTimestamps.now();
+        Tab tab = new Tab(tabId, parentId, groupId, title, url, position, timestamps);
+
+        String newTitleValue = "업데이트된 제목";
+        String newUrlValue = "https://updated.com";
+
+        // when
+        Tab updatedTab = tab.updateInfo(newTitleValue, newUrlValue);
+
+        // then
+        assertAll(
+                () -> assertThat(updatedTab).isNotNull(),
+                () -> assertThat(updatedTab.getId()).isEqualTo(tabId),
+                () -> assertThat(updatedTab.getParentId()).isEqualTo(parentId),
+                () -> assertThat(updatedTab.getGroupId()).isEqualTo(groupId),
+                () -> assertThat(updatedTab.getTitle().getValue()).isEqualTo(newTitleValue),
+                () -> assertThat(updatedTab.getUrl().getValue()).isEqualTo(newUrlValue),
+                () -> assertThat(updatedTab.getPosition()).isEqualTo(position),
+                () -> assertThat(updatedTab.getUpdatedAt()).isAfter(timestamps.getUpdatedAt())
+        );
+    }
+
+    @Test
+    void updatePosition으로_위치를_업데이트할_수_있다() {
+        // given
+        TabId tabId = TabId.create(1L);
+        TabId parentId = TabId.create(10L);
+        GroupId groupId = GroupId.create(100L);
+        TabTitle title = TabTitle.create("테스트 탭");
+        TabUrl url = TabUrl.create("https://example.com");
+        TabPosition position = TabPosition.create(0);
+        AuditTimestamps timestamps = AuditTimestamps.now();
+        Tab tab = new Tab(tabId, parentId, groupId, title, url, position, timestamps);
+
+        int newPositionValue = 5;
+
+        // when
+        Tab updatedTab = tab.updatePosition(newPositionValue);
+
+        // then
+        assertAll(
+                () -> assertThat(updatedTab).isNotNull(),
+                () -> assertThat(updatedTab.getId()).isEqualTo(tabId),
+                () -> assertThat(updatedTab.getParentId()).isEqualTo(parentId),
+                () -> assertThat(updatedTab.getGroupId()).isEqualTo(groupId),
+                () -> assertThat(updatedTab.getTitle()).isEqualTo(title),
+                () -> assertThat(updatedTab.getUrl()).isEqualTo(url),
+                () -> assertThat(updatedTab.getPosition().getValue()).isEqualTo(newPositionValue),
+                () -> assertThat(updatedTab.getUpdatedAt()).isAfter(timestamps.getUpdatedAt())
+        );
+    }
+
+    @Test
+    void moveTo로_위치를_변경할_수_있다() {
+        // given
+        TabId tabId = TabId.create(1L);
+        TabId parentId = TabId.create(10L);
+        GroupId groupId = GroupId.create(100L);
+        TabTitle title = TabTitle.create("테스트 탭");
+        TabUrl url = TabUrl.create("https://example.com");
+        TabPosition position = TabPosition.create(0);
+        AuditTimestamps timestamps = AuditTimestamps.now();
+        Tab tab = new Tab(tabId, parentId, groupId, title, url, position, timestamps);
+
+        TabId newParentId = TabId.create(20L);
+        int newPositionValue = 2;
+
+        // when
+        Tab movedTab = tab.moveTo(newParentId, newPositionValue);
+
+        // then
+        assertAll(
+                () -> assertThat(movedTab).isNotNull(),
+                () -> assertThat(movedTab.getId()).isEqualTo(tabId),
+                () -> assertThat(movedTab.getParentId()).isEqualTo(newParentId),
+                () -> assertThat(movedTab.getGroupId()).isEqualTo(groupId),
+                () -> assertThat(movedTab.getTitle()).isEqualTo(title),
+                () -> assertThat(movedTab.getUrl()).isEqualTo(url),
+                () -> assertThat(movedTab.getPosition().getValue()).isEqualTo(newPositionValue),
+                () -> assertThat(movedTab.getUpdatedAt()).isAfter(timestamps.getUpdatedAt())
+        );
+    }
+
+    @Test
+    void parentId가_null이면_루트_탭이다() {
+        // given
+        TabId tabId = TabId.create(1L);
+        GroupId groupId = GroupId.create(100L);
+        TabTitle title = TabTitle.create("테스트 탭");
+        TabUrl url = TabUrl.create("https://example.com");
+        TabPosition position = TabPosition.create(0);
+        AuditTimestamps timestamps = AuditTimestamps.now();
+        Tab rootTab = new Tab(tabId, null, groupId, title, url, position, timestamps);
+
+        // when
+        boolean isRoot = rootTab.isRoot();
+
+        // then
+        assertThat(isRoot).isTrue();
+    }
+
+    @Test
+    void parentId가_있으면_루트_탭이_아니다() {
+        // given
+        TabId tabId = TabId.create(1L);
+        TabId parentId = TabId.create(10L);
+        GroupId groupId = GroupId.create(100L);
+        TabTitle title = TabTitle.create("테스트 탭");
+        TabUrl url = TabUrl.create("https://example.com");
+        TabPosition position = TabPosition.create(0);
+        AuditTimestamps timestamps = AuditTimestamps.now();
+        Tab tab = new Tab(tabId, parentId, groupId, title, url, position, timestamps);
+
+        // when
+        boolean isRoot = tab.isRoot();
+
+        // then
+        assertThat(isRoot).isFalse();
+    }
+
+    @Test
+    void getCreatedAt으로_생성_시간을_조회할_수_있다() {
+        // given
+        TabId tabId = TabId.create(1L);
+        TabId parentId = TabId.create(10L);
+        GroupId groupId = GroupId.create(100L);
+        TabTitle title = TabTitle.create("테스트 탭");
+        TabUrl url = TabUrl.create("https://example.com");
+        TabPosition position = TabPosition.create(0);
+        AuditTimestamps timestamps = AuditTimestamps.now();
+        Tab tab = new Tab(tabId, parentId, groupId, title, url, position, timestamps);
+
+        // when
+        LocalDateTime createdAt = tab.getCreatedAt();
+
+        // then
+        assertAll(
+                () -> assertThat(createdAt).isNotNull(),
+                () -> assertThat(createdAt).isEqualTo(timestamps.getCreatedAt())
+        );
+    }
+
+    @Test
+    void getUpdatedAt으로_수정_시간을_조회할_수_있다() {
+        // given
+        TabId tabId = TabId.create(1L);
+        TabId parentId = TabId.create(10L);
+        GroupId groupId = GroupId.create(100L);
+        TabTitle title = TabTitle.create("테스트 탭");
+        TabUrl url = TabUrl.create("https://example.com");
+        TabPosition position = TabPosition.create(0);
+        AuditTimestamps timestamps = AuditTimestamps.now();
+        Tab tab = new Tab(tabId, parentId, groupId, title, url, position, timestamps);
+
+        // when
+        LocalDateTime updatedAt = tab.getUpdatedAt();
+
+        // then
+        assertAll(
+                () -> assertThat(updatedAt).isNotNull(),
+                () -> assertThat(updatedAt).isEqualTo(timestamps.getUpdatedAt())
+        );
+    }
+
+    @Test
+    void 같은_id를_가진_Tab은_동등하다() {
+        // given
+        TabId tabId = TabId.create(1L);
+        TabId parentId = TabId.create(10L);
+        GroupId groupId = GroupId.create(100L);
+        TabTitle title = TabTitle.create("테스트 탭");
+        TabUrl url = TabUrl.create("https://example.com");
+        TabPosition position = TabPosition.create(0);
+        AuditTimestamps timestamps = AuditTimestamps.now();
+
+        Tab tab1 = new Tab(tabId, parentId, groupId, title, url, position, timestamps);
+        Tab tab2 = new Tab(tabId, TabId.create(999L), GroupId.create(999L),
+                TabTitle.create("다른 제목"), TabUrl.create("https://different.com"),
+                TabPosition.create(999), AuditTimestamps.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(tab1).isEqualTo(tab2),
+                () -> assertThat(tab1).hasSameHashCodeAs(tab2)
+        );
+    }
+
+    @Test
+    void 다른_id를_가진_Tab은_동등하지_않다() {
+        // given
+        TabId tabId1 = TabId.create(1L);
+        TabId tabId2 = TabId.create(2L);
+        TabId parentId = TabId.create(10L);
+        GroupId groupId = GroupId.create(100L);
+        TabTitle title = TabTitle.create("테스트 탭");
+        TabUrl url = TabUrl.create("https://example.com");
+        TabPosition position = TabPosition.create(0);
+        AuditTimestamps timestamps = AuditTimestamps.now();
+
+        Tab tab1 = new Tab(tabId1, parentId, groupId, title, url, position, timestamps);
+        Tab tab2 = new Tab(tabId2, parentId, groupId, title, url, position, timestamps);
+
+        // when & then
+        assertAll(
+                () -> assertThat(tab1).isNotEqualTo(tab2),
+                () -> assertThat(tab1).doesNotHaveSameHashCodeAs(tab2)
+        );
+    }
+}

--- a/src/test/java/com/management/tab/domain/tab/vo/GroupIdTest.java
+++ b/src/test/java/com/management/tab/domain/tab/vo/GroupIdTest.java
@@ -1,0 +1,75 @@
+package com.management.tab.domain.tab.vo;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GroupIdTest {
+
+    @ParameterizedTest(name = "{0}로 GroupId를 초기화할 수 있다")
+    @ValueSource(longs = {1L, 10L, 100L, 1000L, Long.MAX_VALUE})
+    void 유효한_양수로_GroupId를_초기화할_수_있다(Long value) {
+        // when
+        GroupId groupId = GroupId.create(value);
+
+        // then
+        assertAll(
+                () -> assertThat(groupId).isNotNull(),
+                () -> assertThat(groupId.getValue()).isEqualTo(value)
+        );
+    }
+
+    @Test
+    void null로는_GroupId를_초기화할_수_없다() {
+        // given
+        Long value = null;
+
+        // when & then
+        assertThatThrownBy(() -> GroupId.create(value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("GroupId는 양수여야 합니다");
+    }
+
+    @ParameterizedTest(name = "{0}일 때 GroupId를 초기화할 수 없다")
+    @ValueSource(longs = {-1, 0})
+    void 음수나_0으로는_GroupId를_초기화할_수_없다(Long value) {
+        // when & then
+        assertThatThrownBy(() -> GroupId.create(value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("GroupId는 양수여야 합니다");
+    }
+
+    @Test
+    void 같은_값을_가진_GroupId는_동등하다() {
+        // given
+        GroupId groupId1 = GroupId.create(1L);
+        GroupId groupId2 = GroupId.create(1L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(groupId1).isEqualTo(groupId2),
+                () -> assertThat(groupId1).hasSameHashCodeAs(groupId2)
+        );
+    }
+
+    @Test
+    void 다른_값을_가진_GroupId는_동등하지_않다() {
+        // given
+        GroupId groupId1 = GroupId.create(1L);
+        GroupId groupId2 = GroupId.create(2L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(groupId1).isNotEqualTo(groupId2),
+                () -> assertThat(groupId1).doesNotHaveSameHashCodeAs(groupId2)
+        );
+    }
+}

--- a/src/test/java/com/management/tab/domain/tab/vo/TabIdTest.java
+++ b/src/test/java/com/management/tab/domain/tab/vo/TabIdTest.java
@@ -1,0 +1,91 @@
+package com.management.tab.domain.tab.vo;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TabIdTest {
+
+    @Test
+    void 양수_값으로_TabId를_초기화할_수_있다() {
+        // given
+        Long value = 1L;
+
+        // when
+        TabId tabId = TabId.create(value);
+
+        // then
+        assertAll(
+                () -> assertThat(tabId).isNotNull(),
+                () -> assertThat(tabId.id()).isEqualTo(1L),
+                () -> assertThat(tabId.getValue()).isEqualTo(1L)
+        );
+    }
+
+    @Test
+    void null_값은_TabId_초기화에_실패한다() {
+        // given
+        Long value = null;
+
+        // when & then
+        assertThatThrownBy(() -> TabId.create(value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("TabId는 양수여야 합니다.");
+    }
+
+    @ParameterizedTest(name = "{0}일 때 초기화에 실패한다")
+    @ValueSource(longs = {0, -1})
+    void 유효하지_않은_값으로는_TabId_초기화에_실패한다(Long id) {
+        // when & then
+        assertThatThrownBy(() -> TabId.create(id))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("TabId는 양수여야 합니다.");
+    }
+
+    @Test
+    void 같은_값을_가진_TabId는_동등하다() {
+        // given
+        TabId tabId1 = TabId.create(1L);
+        TabId tabId2 = TabId.create(1L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(tabId1).isEqualTo(tabId2),
+                () -> assertThat(tabId1).hasSameHashCodeAs(tabId2)
+        );
+    }
+
+    @Test
+    void 다른_값을_가진_TabId는_동등하지_않다() {
+        // given
+        TabId tabId1 = TabId.create(1L);
+        TabId tabId2 = TabId.create(2L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(tabId1).isNotEqualTo(tabId2),
+                () -> assertThat(tabId1).doesNotHaveSameHashCodeAs(tabId2)
+        );
+    }
+
+    @Test
+    void id_메서드는_생성_시_전달한_값을_반환한다() {
+        // given
+        Long value = 100L;
+        TabId tabId = TabId.create(value);
+
+        // when
+        Long result = tabId.id();
+
+        // then
+        assertThat(result).isEqualTo(value);
+    }
+}

--- a/src/test/java/com/management/tab/domain/tab/vo/TabPositionTest.java
+++ b/src/test/java/com/management/tab/domain/tab/vo/TabPositionTest.java
@@ -1,0 +1,136 @@
+package com.management.tab.domain.tab.vo;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TabPositionTest {
+
+    @Test
+    void 유효한_0_이상의_값으로_TabPosition을_초기화할_수_있다() {
+        // when
+        TabPosition position = TabPosition.create(0);
+
+        // then
+        assertAll(
+                () -> assertThat(position).isNotNull(),
+                () -> assertThat(position.getValue()).isZero()
+        );
+    }
+
+    @Test
+    void 음수로는_TabPosition을_초기화할_수_없다() {
+        // when & then
+        assertThatThrownBy(() -> TabPosition.create(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("위치는 0 이상이어야 합니다");
+    }
+
+    @Test
+    void defaultPosition은_0을_반환한다() {
+        // when
+        TabPosition defaultPosition = TabPosition.defaultPosition();
+
+        // then
+        assertAll(
+                () -> assertThat(defaultPosition).isNotNull(),
+                () -> assertThat(defaultPosition.getValue()).isZero()
+        );
+    }
+
+    @Test
+    void defaultPosition으로_생성한_TabPosition은_첫_번째_위치이다() {
+        // when
+        TabPosition defaultPosition = TabPosition.defaultPosition();
+
+        // then
+        assertThat(defaultPosition.isFirst()).isTrue();
+    }
+
+    @Test
+    void next는_현재_위치보다_1_증가한_TabPosition을_반환한다() {
+        // given
+        TabPosition position = TabPosition.create(5);
+
+        // when
+        TabPosition nextPosition = position.next();
+
+        // then
+        assertAll(
+                () -> assertThat(nextPosition).isNotNull(),
+                () -> assertThat(nextPosition.getValue()).isEqualTo(6)
+        );
+    }
+
+    @Test
+    void next는_새로운_TabPosition_인스턴스를_반환한다() {
+        // given
+        TabPosition position = TabPosition.create(3);
+
+        // when
+        TabPosition nextPosition = position.next();
+
+        // then
+        assertAll(
+                () -> assertThat(nextPosition).isNotSameAs(position),
+                () -> assertThat(position.getValue()).isEqualTo(3),
+                () -> assertThat(nextPosition.getValue()).isEqualTo(4)
+        );
+    }
+
+    @Test
+    void isFirst는_위치가_0일_때_true를_반환한다() {
+        // given
+        TabPosition position = TabPosition.create(0);
+
+        // when
+        boolean isFirst = position.isFirst();
+
+        // then
+        assertThat(isFirst).isTrue();
+    }
+
+    @Test
+    void isFirst는_위치가_0이_아닐_때_false를_반환한다() {
+        // given
+        TabPosition position = TabPosition.create(1);
+
+        // when
+        boolean isFirst = position.isFirst();
+
+        // then
+        assertThat(isFirst).isFalse();
+    }
+
+    @Test
+    void 같은_값을_가진_TabPosition은_동등하다() {
+        // given
+        TabPosition position1 = TabPosition.create(5);
+        TabPosition position2 = TabPosition.create(5);
+
+        // when & then
+        assertAll(
+                () -> assertThat(position1).isEqualTo(position2),
+                () -> assertThat(position1).hasSameHashCodeAs(position2)
+        );
+    }
+
+    @Test
+    void 다른_값을_가진_TabPosition은_동등하지_않다() {
+        // given
+        TabPosition position1 = TabPosition.create(5);
+        TabPosition position2 = TabPosition.create(10);
+
+        // when & then
+        assertAll(
+                () -> assertThat(position1).isNotEqualTo(position2),
+                () -> assertThat(position1).doesNotHaveSameHashCodeAs(position2)
+        );
+    }
+}

--- a/src/test/java/com/management/tab/domain/tab/vo/TabTitleTest.java
+++ b/src/test/java/com/management/tab/domain/tab/vo/TabTitleTest.java
@@ -1,0 +1,77 @@
+package com.management.tab.domain.tab.vo;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TabTitleTest {
+
+    @Test
+    void 유효한_문자열로_TabTitle을_초기화할_수_있다() {
+        // given
+        String value = "테스트 탭";
+
+        // when
+        TabTitle tabTitle = TabTitle.create(value);
+
+        // then
+        assertAll(
+                () -> assertThat(tabTitle).isNotNull(),
+                () -> assertThat(tabTitle.getValue()).isEqualTo("테스트 탭")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}일 때 초기화에 실패한다")
+    @NullAndEmptySource
+    void 유효하지_않은_문자열으로는_TabTitle을_초기화할_수_없다(String value) {
+        // when & then
+        assertThatThrownBy(() -> TabTitle.create(value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("탭 제목은 비어있을 수 없습니다.");
+    }
+
+    @Test
+    void 최대_길이를_초과하는_문자열로는_TabTitle을_초기화할_수_없다() {
+        // given
+        String value = "a".repeat(51);
+
+        // when & then
+        assertThatThrownBy(() -> TabTitle.create(value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("탭 제목은 50자를 초과할 수 없습니다.");
+    }
+
+    @Test
+    void 같은_값을_가진_TabTitle은_동등하다() {
+        // given
+        TabTitle tabTitle1 = TabTitle.create("테스트");
+        TabTitle tabTitle2 = TabTitle.create("테스트");
+
+        // when & then
+        assertAll(
+                () -> assertThat(tabTitle1).isEqualTo(tabTitle2),
+                () -> assertThat(tabTitle1).hasSameHashCodeAs(tabTitle2)
+        );
+    }
+
+    @Test
+    void 다른_값을_가진_TabTitle은_동등하지_않다() {
+        // given
+        TabTitle tabTitle1 = TabTitle.create("테스트1");
+        TabTitle tabTitle2 = TabTitle.create("테스트2");
+
+        // when & then
+        assertAll(
+                () -> assertThat(tabTitle1).isNotEqualTo(tabTitle2),
+                () -> assertThat(tabTitle1).doesNotHaveSameHashCodeAs(tabTitle2)
+        );
+    }
+}

--- a/src/test/java/com/management/tab/domain/tab/vo/TabUrlTest.java
+++ b/src/test/java/com/management/tab/domain/tab/vo/TabUrlTest.java
@@ -1,0 +1,91 @@
+package com.management.tab.domain.tab.vo;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TabUrlTest {
+
+    @ParameterizedTest(name = "{0}로 TabUrl을 초기화할 수 있다")
+    @ValueSource(strings = {
+            "https://www.example.com",
+            "http://example.com",
+            "https://example.com/path",
+            "https://example.com/path?query=value",
+            "https://subdomain.example.com",
+            "https://example.com:8080/path",
+            "http://www.example.co.kr"
+    })
+    void 유효한_URL로_TabUrl을_초기화할_수_있다(String value) {
+        // when
+        TabUrl tabUrl = TabUrl.create(value);
+
+        // then
+        assertAll(
+                () -> assertThat(tabUrl).isNotNull(),
+                () -> assertThat(tabUrl.getValue()).isEqualTo(value)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}일 때 초기화에 실패한다")
+    @NullAndEmptySource
+    void 유효하지_않은_문자열으로는_TabUrl을_초기화할_수_없다(String value) {
+        // when & then
+        assertThatThrownBy(() -> TabUrl.create(value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("탭 URL은 비어있을 수 없습니다");
+    }
+
+    @ParameterizedTest(name = "{0}로 TabUrl을 초기화할 수 없다")
+    @ValueSource(strings = {
+            "ftp://example.com",
+            "example.com",
+            "www.example.com",
+            "https:/example.com",
+            "https://",
+            "http://",
+            "://example.com",
+            "https//example.com"
+    })
+    void 유효하지_않은_URL_형식으로는_TabUrl을_초기화할_수_없다(String value) {
+        // when & then
+        assertThatThrownBy(() -> TabUrl.create(value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("유효한 URL 형식이 아닙니다");
+    }
+
+    @Test
+    void 같은_값을_가진_TabUrl은_동등하다() {
+        // given
+        TabUrl tabUrl1 = TabUrl.create("https://example.com");
+        TabUrl tabUrl2 = TabUrl.create("https://example.com");
+
+        // when & then
+        assertAll(
+                () -> assertThat(tabUrl1).isEqualTo(tabUrl2),
+                () -> assertThat(tabUrl1).hasSameHashCodeAs(tabUrl2)
+        );
+    }
+
+    @Test
+    void 다른_값을_가진_TabUrl은_동등하지_않다() {
+        // given
+        TabUrl tabUrl1 = TabUrl.create("https://example.com");
+        TabUrl tabUrl2 = TabUrl.create("https://google.com");
+
+        // when & then
+        assertAll(
+                () -> assertThat(tabUrl1).isNotEqualTo(tabUrl2),
+                () -> assertThat(tabUrl1).doesNotHaveSameHashCodeAs(tabUrl2)
+        );
+    }
+}


### PR DESCRIPTION
# 관련 이슈 

- closed #1 

# 작업 요약

- 탭 관련 도메인 추가

# Task

- Tab 도메인 추가 
- Tab 도메인 빌더 추가
- Tab 도메인에 필요한 VO 추가
  - TabId
  - TabTitle
  - TabUrl
  - TabPosition
  - GroupId
- 공통 VO 추가
  - AuditTimestamps 