### PR TITLE
탭, 탭 그룹 관련 리포지토리, 서비스 기능 추가

### DIFF
--- a/src/main/java/com/management/tab/application/TabGroupService.java
+++ b/src/main/java/com/management/tab/application/TabGroupService.java
@@ -1,0 +1,49 @@
+package com.management.tab.application;
+
+import com.management.tab.domain.group.TabGroup;
+import com.management.tab.domain.group.vo.TabGroupId;
+import com.management.tab.domain.repository.TabGroupRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TabGroupService {
+
+    private final TabGroupRepository tabGroupRepository;
+
+    public List<TabGroup> getAllGroups() {
+        return tabGroupRepository.findAll();
+    }
+
+    public TabGroup getGroup(Long id) {
+        return tabGroupRepository.findById(id);
+    }
+
+    @Transactional
+    public TabGroupId createGroup(String name) {
+        TabGroup tabGroup = TabGroup.create(name);
+
+        return tabGroupRepository.save(tabGroup)
+                                 .getId();
+    }
+
+    @Transactional
+    public void updateGroup(Long id, String name) {
+        TabGroup tabGroup = tabGroupRepository.findById(id);
+        TabGroup renamedTabGroup = tabGroup.rename(name);
+
+        tabGroupRepository.updateRenamed(renamedTabGroup);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        tabGroupRepository.delete(id);
+    }
+
+    public int countTabs(Long id) {
+        return tabGroupRepository.countTabs(id);
+    }
+}

--- a/src/main/java/com/management/tab/application/TabService.java
+++ b/src/main/java/com/management/tab/application/TabService.java
@@ -1,0 +1,176 @@
+package com.management.tab.application;
+
+import com.management.tab.domain.group.vo.TabGroupId;
+import com.management.tab.domain.repository.TabRepository;
+import com.management.tab.domain.tab.Tab;
+import com.management.tab.domain.tab.TabBuilder;
+import com.management.tab.domain.tab.TabTree;
+import com.management.tab.domain.tab.vo.TabId;
+import com.management.tab.domain.tab.vo.TabPosition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TabService {
+
+    private final TabRepository tabRepository;
+
+    @Transactional
+    public TabId createRootTab(Long groupId, String title, String url) {
+        TabPosition lastRootPosition = tabRepository.findLastRootPosition(groupId);
+        Tab rootTab = TabBuilder.createRoot(groupId, title, url, lastRootPosition.next())
+                                .build();
+
+        return tabRepository.saveRoot(rootTab)
+                            .getId();
+    }
+
+    @Transactional
+    public TabId createChildTab(Long parentId, String title, String url) {
+        Tab parentTab = tabRepository.findTab(parentId);
+        TabTree tabTree = tabRepository.findTabTree(parentTab.getTabGroupId());
+
+        tabTree.validateAddChildDepth(parentTab.getId());
+
+        TabPosition nextChildPosition = tabTree.getNextChildPosition(parentTab.getId());
+        Tab childTab = TabBuilder.createChild(parentTab, title, url, nextChildPosition)
+                                 .build();
+
+        return tabRepository.saveChild(childTab)
+                            .getId();
+    }
+
+    @Transactional
+    public void deleteTab(Long tabId) {
+        Tab tab = tabRepository.findTab(tabId);
+
+        tabRepository.deleteTab(tab);
+    }
+
+    @Transactional
+    public void deleteTabWithSubtree(Long tabId) {
+        Tab tab = tabRepository.findTab(tabId);
+
+        tabRepository.deleteTabWithSubtree(tab);
+    }
+
+    @Transactional
+    public void moveRoot(Long tabId) {
+        Tab tab = tabRepository.findTab(tabId);
+        TabTree tabTree = tabRepository.findTabTree(tab.getTabGroupId());
+        TabPosition nextRootPosition = tabTree.getNextRootPosition();
+        Tab movedTab = tab.moveToRoot(nextRootPosition);
+
+        tabRepository.updateMovedRoot(movedTab, tab.getParentId());
+    }
+
+    @Transactional
+    public void moveRootWithSubtree(Long tabId) {
+        Tab tab = tabRepository.findTab(tabId);
+        TabTree tabTree = tabRepository.findTabTree(tab.getTabGroupId());
+        TabPosition nextRootPosition = tabTree.getNextRootPosition();
+        Tab movedTab = tab.moveToRoot(nextRootPosition);
+
+        tabRepository.updateMovedRootWithSubtree(movedTab);
+    }
+
+    @Transactional
+    public void move(Long tabId, Long newParentId) {
+        Tab tab = tabRepository.findTab(tabId);
+        TabTree tabTree = tabRepository.findTabTree(tab.getTabGroupId());
+
+        tabTree.validateMove(tab.getId(), TabId.create(newParentId));
+        tabTree.validateMoveDepth(TabId.create(newParentId));
+
+        TabPosition nextChildPosition = tabTree.getNextChildPosition(TabId.create(newParentId));
+        Tab movedTab = tab.moveTo(TabId.create(newParentId), nextChildPosition);
+
+        tabRepository.updateMoved(movedTab, tab.getParentId());
+    }
+
+    @Transactional
+    public void moveWithSubtree(Long tabId, Long newParentId) {
+        Tab tab = tabRepository.findTab(tabId);
+        TabTree tabTree = tabRepository.findTabTree(tab.getTabGroupId());
+
+        tabTree.validateMove(tab.getId(), TabId.create(newParentId));
+        tabTree.validateMoveDepthWithSubtree(tab.getId(), TabId.create(newParentId));
+
+        TabPosition nextChildPosition = tabTree.getNextChildPosition(TabId.create(newParentId));
+        Tab movedTab = tab.moveTo(TabId.create(newParentId), nextChildPosition);
+
+        tabRepository.updateMovedTabWithSubtree(movedTab);
+    }
+
+    @Transactional
+    public void reorderTab(Long tabId, Long targetTabId, boolean after) {
+        TabId movingParentId = tabRepository.findParentId(tabId);
+        TabId targetParentId = tabRepository.findParentId(targetTabId);
+
+        validateReorderTab(movingParentId, targetParentId);
+
+        Tab movingTab = tabRepository.findTab(tabId);
+        List<Tab> siblings = findMovingSiblings(movingParentId, movingTab);
+        int targetIndex = findTabIndexInDomain(siblings, TabId.create(targetTabId));
+        int insertIndex = after ? targetIndex + 1 : targetIndex;
+        List<Tab> reorderedSiblings = new ArrayList<>(siblings);
+
+        reorderedSiblings.add(insertIndex, movingTab);
+
+        for (int i = 0; i < reorderedSiblings.size(); i++) {
+            Tab sibling = reorderedSiblings.get(i);
+            Tab updatedTab = sibling.updatePosition(i);
+
+            tabRepository.updatePosition(
+                    updatedTab.getId(),
+                    updatedTab.getPosition()
+            );
+        }
+    }
+
+    private void validateReorderTab(TabId movingParentId, TabId targetParentId) {
+        boolean sameLevel = (movingParentId == null && targetParentId == null)
+                || (movingParentId != null && movingParentId.equals(targetParentId));
+
+        if (!sameLevel) {
+            throw new IllegalArgumentException("같은 레벨의 탭만 순서를 변경할 수 있습니다");
+        }
+    }
+
+    private List<Tab> findMovingSiblings(TabId movingParentId, Tab movingTab) {
+        if (movingParentId == null) {
+           return tabRepository.findRootSiblings()
+                               .stream()
+                               .filter(tab -> !tab.isEqualId(movingTab))
+                               .toList();
+        }
+
+        return tabRepository.findSiblings(movingParentId)
+                            .stream()
+                            .filter(tab -> !tab.isEqualId(movingTab))
+                            .toList();
+    }
+
+    private int findTabIndexInDomain(List<Tab> tabs, TabId targetId) {
+        return IntStream.range(0, tabs.size())
+                        .filter(i -> tabs.get(i).isEqualTo(targetId))
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalArgumentException("대상 탭을 찾을 수 없습니다."));
+    }
+
+    public void updateTab(Long tabId, String title, String url) {
+        Tab tab = tabRepository.findTab(tabId);
+        Tab updatedTab = tab.updateInfo(title, url);
+
+        tabRepository.updateTabInfo(updatedTab);
+    }
+
+    public TabTree getTabTree(Long groupId) {
+        return tabRepository.findTabTree(TabGroupId.create(groupId));
+    }
+}

--- a/src/main/java/com/management/tab/application/TabService.java
+++ b/src/main/java/com/management/tab/application/TabService.java
@@ -163,6 +163,7 @@ public class TabService {
                         .orElseThrow(() -> new IllegalArgumentException("대상 탭을 찾을 수 없습니다."));
     }
 
+    @Transactional
     public void updateTab(Long tabId, String title, String url) {
         Tab tab = tabRepository.findTab(tabId);
         Tab updatedTab = tab.updateInfo(title, url);

--- a/src/main/java/com/management/tab/domain/common/AuditTimestamps.java
+++ b/src/main/java/com/management/tab/domain/common/AuditTimestamps.java
@@ -12,6 +12,10 @@ public class AuditTimestamps {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
+    public static AuditTimestamps create(LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return new AuditTimestamps(createdAt, updatedAt);
+    }
+
     public static AuditTimestamps now() {
         LocalDateTime now = LocalDateTime.now();
 

--- a/src/main/java/com/management/tab/domain/group/TabGroup.java
+++ b/src/main/java/com/management/tab/domain/group/TabGroup.java
@@ -3,6 +3,7 @@ package com.management.tab.domain.group;
 import com.management.tab.domain.common.AuditTimestamps;
 import com.management.tab.domain.group.vo.TabGroupId;
 import com.management.tab.domain.group.vo.TabGroupName;
+import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
@@ -14,6 +15,14 @@ public class TabGroup {
 
     public static TabGroup create(String name) {
         return new TabGroup(null, TabGroupName.create(name), AuditTimestamps.now());
+    }
+
+    public static TabGroup create(Long groupId, String name, LocalDateTime createAt, LocalDateTime updatedAt) {
+        return new TabGroup(
+                TabGroupId.create(groupId),
+                TabGroupName.create(name),
+                AuditTimestamps.create(createAt, updatedAt)
+        );
     }
 
     public static TabGroup createWithAssignedId(Long id, TabGroup tabGroup) {

--- a/src/main/java/com/management/tab/domain/repository/TabGroupRepository.java
+++ b/src/main/java/com/management/tab/domain/repository/TabGroupRepository.java
@@ -1,0 +1,19 @@
+package com.management.tab.domain.repository;
+
+import com.management.tab.domain.group.TabGroup;
+import java.util.List;
+
+public interface TabGroupRepository {
+
+    List<TabGroup> findAll();
+
+    TabGroup findById(Long id);
+
+    TabGroup save(TabGroup tabGroup);
+
+    void update(Long id, String name);
+
+    void delete(Long id);
+
+    int countTabs(Long groupId);
+}

--- a/src/main/java/com/management/tab/domain/repository/TabGroupRepository.java
+++ b/src/main/java/com/management/tab/domain/repository/TabGroupRepository.java
@@ -11,9 +11,9 @@ public interface TabGroupRepository {
 
     TabGroup save(TabGroup tabGroup);
 
-    void update(Long id, String name);
+    void updateRenamed(TabGroup renamedTabGroup);
 
     void delete(Long id);
 
-    int countTabs(Long groupId);
+    int countTabs(Long id);
 }

--- a/src/main/java/com/management/tab/domain/repository/TabRepository.java
+++ b/src/main/java/com/management/tab/domain/repository/TabRepository.java
@@ -1,0 +1,43 @@
+package com.management.tab.domain.repository;
+
+import com.management.tab.domain.group.vo.TabGroupId;
+import com.management.tab.domain.tab.Tab;
+import com.management.tab.domain.tab.TabTree;
+import com.management.tab.domain.tab.vo.TabId;
+import com.management.tab.domain.tab.vo.TabPosition;
+import java.util.List;
+
+public interface TabRepository {
+
+    Tab saveRoot(Tab rootTab);
+
+    Tab saveChild(Tab childTab);
+
+    Tab findTab(Long tabId);
+
+    TabTree findTabTree(TabGroupId groupId);
+
+    TabId findParentId(Long tabId);
+
+    TabPosition findLastRootPosition(Long groupId);
+
+    List<Tab> findSiblings(TabId parentId);
+
+    List<Tab> findRootSiblings();
+
+    void updateMoved(Tab movedTab, TabId currentParentId);
+
+    void updateMovedTabWithSubtree(Tab movedTab);
+
+    void updateMovedRoot(Tab movedTab, TabId currentParentId);
+
+    void updateMovedRootWithSubtree(Tab movedTab);
+
+    void updatePosition(TabId id, TabPosition position);
+
+    void updateTabInfo(Tab updatedTab);
+
+    void deleteTabWithSubtree(Tab tab);
+
+    void deleteTab(Tab tab);
+}

--- a/src/main/java/com/management/tab/domain/tab/Tab.java
+++ b/src/main/java/com/management/tab/domain/tab/Tab.java
@@ -97,6 +97,10 @@ public class Tab {
         return this.id.equals(other.id);
     }
 
+    public boolean isEqualTo(TabId id) {
+        return this.id.equals(id);
+    }
+
     public LocalDateTime getCreatedAt() {
         return timestamps.getCreatedAt();
     }

--- a/src/main/java/com/management/tab/persistence/JdbcTabGroupRepository.java
+++ b/src/main/java/com/management/tab/persistence/JdbcTabGroupRepository.java
@@ -41,8 +41,8 @@ public class JdbcTabGroupRepository implements TabGroupRepository {
     }
 
     @Override
-    public void update(Long id, String name) {
-        tabGroupDao.update(id, name);
+    public void updateRenamed(TabGroup renamedTabGroup) {
+        tabGroupDao.update(renamedTabGroup.getId().getValue(), renamedTabGroup.getName().getValue());
     }
 
     @Override
@@ -51,7 +51,7 @@ public class JdbcTabGroupRepository implements TabGroupRepository {
     }
 
     @Override
-    public int countTabs(Long groupId) {
-        return tabGroupDao.countTabs(groupId);
+    public int countTabs(Long id) {
+        return tabGroupDao.countTabs(id);
     }
 }

--- a/src/main/java/com/management/tab/persistence/JdbcTabGroupRepository.java
+++ b/src/main/java/com/management/tab/persistence/JdbcTabGroupRepository.java
@@ -1,0 +1,57 @@
+package com.management.tab.persistence;
+
+import com.management.tab.domain.group.TabGroup;
+import com.management.tab.domain.repository.TabGroupRepository;
+import com.management.tab.persistence.dao.TabGroupDao;
+import com.management.tab.persistence.dao.dto.TabGroupDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcTabGroupRepository implements TabGroupRepository {
+
+    private final TabGroupDao tabGroupDao;
+
+    @Override
+    public List<TabGroup> findAll() {
+        return tabGroupDao.findAll()
+                          .stream()
+                          .map(TabGroupDto::toTabGroup)
+                          .toList();
+    }
+
+    @Override
+    public TabGroup findById(Long id) {
+        return tabGroupDao.findById(id)
+                .map(TabGroupDto::toTabGroup)
+                .orElseThrow(() -> new IllegalArgumentException("지정한 ID에 해당하는 탭 그룹이 없습니다."));
+    }
+
+    @Override
+    public TabGroup save(TabGroup tabGroup) {
+        Long tabGroupId = tabGroupDao.save(
+                tabGroup.getName().getValue(),
+                tabGroup.getTimestamps().getCreatedAt(),
+                tabGroup.getTimestamps().getUpdatedAt()
+        );
+
+        return TabGroup.createWithAssignedId(tabGroupId, tabGroup);
+    }
+
+    @Override
+    public void update(Long id, String name) {
+        tabGroupDao.update(id, name);
+    }
+
+    @Override
+    public void delete(Long id) {
+        tabGroupDao.delete(id);
+    }
+
+    @Override
+    public int countTabs(Long groupId) {
+        return tabGroupDao.countTabs(groupId);
+    }
+}

--- a/src/main/java/com/management/tab/persistence/JdbcTabRepository.java
+++ b/src/main/java/com/management/tab/persistence/JdbcTabRepository.java
@@ -100,7 +100,11 @@ public class JdbcTabRepository implements TabRepository {
     @Override
     public TabId findParentId(Long tabId) {
         Long parentId = selectTabDao.findParentId(tabId)
-                                    .orElseThrow(() -> new IllegalArgumentException("부모 ID가 없습니다."));
+                                    .orElse(null);
+
+        if (parentId == null) {
+            return null;
+        }
 
         return TabId.create(parentId);
     }

--- a/src/main/java/com/management/tab/persistence/JdbcTabRepository.java
+++ b/src/main/java/com/management/tab/persistence/JdbcTabRepository.java
@@ -1,0 +1,178 @@
+package com.management.tab.persistence;
+
+import com.management.tab.domain.group.vo.TabGroupId;
+import com.management.tab.domain.repository.TabRepository;
+import com.management.tab.domain.tab.Tab;
+import com.management.tab.domain.tab.TabBuilder;
+import com.management.tab.domain.tab.TabNode;
+import com.management.tab.domain.tab.TabTree;
+import com.management.tab.domain.tab.vo.TabId;
+import com.management.tab.domain.tab.vo.TabPosition;
+import com.management.tab.persistence.dao.DeleteTabDao;
+import com.management.tab.persistence.dao.InsertTabDao;
+import com.management.tab.persistence.dao.SelectTabDao;
+import com.management.tab.persistence.dao.UpdateTabDao;
+import com.management.tab.persistence.dao.dto.TabDto;
+import com.management.tab.persistence.dao.dto.TabWithDepthDto;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcTabRepository implements TabRepository {
+
+    private final InsertTabDao insertTabDao;
+    private final SelectTabDao selectTabDao;
+    private final UpdateTabDao updateTabDao;
+    private final DeleteTabDao deleteTabDao;
+
+    @Override
+    public Tab saveRoot(Tab rootTab) {
+        Long rootTabId = insertTabDao.saveRootTab(
+                rootTab.getTabGroupId().getValue(),
+                rootTab.getTitle().getValue(),
+                rootTab.getUrl().getValue(),
+                rootTab.getPosition().getValue(),
+                rootTab.getCreatedAt(),
+                rootTab.getUpdatedAt()
+        );
+
+        return TabBuilder.createWithAssignedId(rootTabId, rootTab)
+                         .build();
+    }
+
+    @Override
+    public Tab saveChild(Tab childTab) {
+        Long childTabId = insertTabDao.saveChildTab(
+                childTab.getTabGroupId().getValue(),
+                childTab.getTitle().getValue(),
+                childTab.getUrl().getValue(),
+                childTab.getParentId().id(),
+                childTab.getPosition().getValue(),
+                childTab.getCreatedAt(),
+                childTab.getUpdatedAt()
+        );
+
+        return TabBuilder.createWithAssignedId(childTabId, childTab)
+                         .build();
+    }
+
+    @Override
+    public Tab findTab(Long tabId) {
+        return selectTabDao.findById(tabId)
+                           .orElseThrow(() -> new IllegalArgumentException("지정한 탭을 찾을 수 없습니다."))
+                           .toTab();
+    }
+
+    @Override
+    public TabTree findTabTree(TabGroupId groupId) {
+        List<TabWithDepthDto> tabWithDepthDtos = selectTabDao.findTreeByGroup(groupId.getValue());
+        Map<Long, TabNode> nodeMap = new HashMap<>();
+        List<TabNode> rootNodes = new ArrayList<>();
+
+        for (TabWithDepthDto tabWithDepthDto : tabWithDepthDtos) {
+            TabNode tabNode = tabWithDepthDto.toTabNode();
+
+            nodeMap.put(tabNode.getId().getValue(), tabNode);
+
+            if (tabNode.getParentId() == null) {
+                rootNodes.add(tabNode);
+            }
+        }
+
+        for (TabWithDepthDto dto : tabWithDepthDtos) {
+            if (dto.hasParent()) {
+                dto.findParentNode(nodeMap)
+                   .ifPresent(
+                           parent -> dto.findChildNode(nodeMap)
+                                        .ifPresent(parent::addChild)
+                   );
+            }
+        }
+
+        return TabTree.create(groupId.getValue(), rootNodes);
+    }
+
+    @Override
+    public TabId findParentId(Long tabId) {
+        Long parentId = selectTabDao.findParentId(tabId)
+                                    .orElseThrow(() -> new IllegalArgumentException("부모 ID가 없습니다."));
+
+        return TabId.create(parentId);
+    }
+
+    @Override
+    public TabPosition findLastRootPosition(Long groupId) {
+        int lastPosition = selectTabDao.findRootTabLastPosition(groupId);
+
+        return TabPosition.create(lastPosition);
+    }
+
+    @Override
+    public List<Tab> findSiblings(TabId parentId) {
+        return selectTabDao.findSiblings(parentId.id())
+                           .stream()
+                           .map(TabDto::toTab)
+                           .toList();
+    }
+
+    @Override
+    public List<Tab> findRootSiblings() {
+        return selectTabDao.findRootSiblings()
+                           .stream()
+                           .map(TabDto::toTab)
+                           .toList();
+    }
+
+    @Override
+    public void updateMoved(Tab movedTab, TabId currentParentId) {
+        updateTabDao.updateMovingTabOnly(
+                movedTab.getId().id(),
+                currentParentId.id(),
+                movedTab.getParentId().id()
+        );
+    }
+
+    @Override
+    public void updateMovedTabWithSubtree(Tab movedTab) {
+        updateTabDao.updateMovingTabWithSubtree(movedTab.getId().id(), movedTab.getParentId().id());
+    }
+
+    @Override
+    public void updateMovedRoot(Tab movedTab, TabId currentParentId) {
+        updateTabDao.updateMovingTabOnly(movedTab.getId().id(), currentParentId.id(), null);
+    }
+
+    @Override
+    public void updateMovedRootWithSubtree(Tab movedTab) {
+        updateTabDao.updateMovingTabWithSubtree(movedTab.getId().id(), null);
+    }
+
+    @Override
+    public void updatePosition(TabId id, TabPosition position) {
+        updateTabDao.updatePosition(id.id(), position.getValue());
+    }
+
+    @Override
+    public void updateTabInfo(Tab updatedTab) {
+        updateTabDao.updateTab(
+                updatedTab.getId().id(),
+                updatedTab.getTitle().getValue(),
+                updatedTab.getUrl().getValue()
+        );
+    }
+
+    @Override
+    public void deleteTabWithSubtree(Tab tab) {
+        deleteTabDao.deleteTabWithSubtree(tab.getId().id());
+    }
+
+    @Override
+    public void deleteTab(Tab tab) {
+        deleteTabDao.deleteTabOnly(tab.getId().id(), tab.getParentId().id());
+    }
+}

--- a/src/main/java/com/management/tab/persistence/dao/SelectTabDao.java
+++ b/src/main/java/com/management/tab/persistence/dao/SelectTabDao.java
@@ -18,7 +18,7 @@ public class SelectTabDao {
     private static final RowMapper<TabDto> tabRowMapper = (rs, rowNum) -> new TabDto(
             rs.getLong("id"),
             rs.getLong("group_id"),
-            rs.getLong("parent_id"),
+            rs.getObject("parent_id", Long.class),
             rs.getString("title"),
             rs.getString("url"),
             rs.getInt("position"),
@@ -93,17 +93,16 @@ public class SelectTabDao {
 
     public List<TabDto> findSiblings(Long parentId) {
         MapSqlParameterSource parameters = new MapSqlParameterSource();
-
-        if (parentId == null) {
-            String sql = "SELECT * FROM tabs WHERE parent_id IS NULL ORDER BY position";
-
-            return jdbcTemplate.query(sql, parameters, tabRowMapper);
-        }
-
         String sql = "SELECT * FROM tabs WHERE parent_id = :parentId ORDER BY position";
 
         parameters.addValue("parentId", parentId);
         return jdbcTemplate.query(sql, parameters, tabRowMapper);
+    }
+
+    public List<TabDto> findRootSiblings() {
+        String sql = "SELECT * FROM tabs WHERE parent_id IS NULL ORDER BY position";
+
+        return jdbcTemplate.query(sql, new MapSqlParameterSource(), tabRowMapper);
     }
 
     public int findTabLastPosition(Long groupId, Long parentId) {

--- a/src/main/java/com/management/tab/persistence/dao/dto/TabGroupDto.java
+++ b/src/main/java/com/management/tab/persistence/dao/dto/TabGroupDto.java
@@ -1,6 +1,11 @@
 package com.management.tab.persistence.dao.dto;
 
+import com.management.tab.domain.group.TabGroup;
 import java.time.LocalDateTime;
 
 public record TabGroupDto(Long id, String name, LocalDateTime createAt, LocalDateTime updatedAt) {
+
+    public TabGroup toTabGroup() {
+        return TabGroup.create(id, name, createAt, updatedAt);
+    }
 }

--- a/src/test/java/com/management/tab/application/TabGroupServiceTest.java
+++ b/src/test/java/com/management/tab/application/TabGroupServiceTest.java
@@ -1,0 +1,103 @@
+package com.management.tab.application;
+
+import com.management.tab.domain.group.TabGroup;
+import com.management.tab.domain.group.vo.TabGroupId;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@Sql(scripts = {"classpath:sql/schema.sql", "classpath:sql/insert-tab-group-service-test-data.sql"})
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TabGroupServiceTest {
+
+    @Autowired
+    TabGroupService tabGroupService;
+
+    @Test
+    void 모든_탭_그룹을_조회한다() {
+        // when
+        List<TabGroup> actual = tabGroupService.getAllGroups();
+
+        // then
+        assertThat(actual).hasSize(2);
+    }
+
+    @Test
+    void ID로_특정_탭_그룹을_조회한다() {
+        // when
+        TabGroup actual = tabGroupService.getGroup(1L);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual.getName().getValue()).isEqualTo("테스트 그룹1")
+        );
+    }
+
+    @Test
+    void 새로운_탭_그룹을_초기화한다() {
+        // when
+        TabGroupId actual = tabGroupService.createGroup("새로운 그룹");
+
+        // then
+        assertThat(actual).isNotNull();
+    }
+
+    @Test
+    void 탭_그룹_이름을_변경한다() {
+        // when
+        tabGroupService.updateGroup(1L, "변경된 이름");
+
+        // then
+        TabGroup actual = tabGroupService.getGroup(1L);
+
+        assertThat(actual.getName().getValue()).isEqualTo("변경된 이름");
+    }
+
+    @Test
+    void 탭_그룹을_삭제한다() {
+        // when
+        tabGroupService.delete(2L);
+
+        // then
+        List<TabGroup> actual = tabGroupService.getAllGroups();
+
+        assertAll(
+                () -> assertThat(actual).hasSize(1),
+                () -> assertThat(actual).extracting("id")
+                                        .extracting("value")
+                                        .doesNotContain(2L)
+        );
+    }
+
+    @Test
+    void 탭_그룹이_가지고_있는_탭_개수를_조회한다() {
+        // when
+        int actual = tabGroupService.countTabs(1L);
+
+        // then
+        assertThat(actual).isEqualTo(6);
+    }
+
+    @ParameterizedTest(name = "{0}일 때 탭 그룹을 초기화할 수 없다")
+    @NullAndEmptySource
+    void 빈_이름으로_탭_그룹을_초기화할_수_없다(String name) {
+        // when & then
+        assertThatThrownBy(() -> tabGroupService.createGroup(name))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("탭 그룹 이름은 비어있을 수 없습니다.");
+    }
+}
+

--- a/src/test/java/com/management/tab/application/TabServiceTest.java
+++ b/src/test/java/com/management/tab/application/TabServiceTest.java
@@ -1,0 +1,356 @@
+package com.management.tab.application;
+
+import com.management.tab.domain.tab.TabTree;
+import com.management.tab.domain.tab.vo.TabId;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@SpringBootTest
+@Sql(scripts = {"classpath:sql/schema.sql", "classpath:sql/insert-tab-service-test-data.sql"})
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class TabServiceTest {
+
+    @Autowired
+    TabService tabService;
+
+    @Test
+    void 루트_탭을_생성할_수_있다() {
+        // given
+        Long groupId = 1L;
+        String title = "새 루트 탭";
+        String url = "https://new-root.com";
+
+        // when
+        TabId actual = tabService.createRootTab(groupId, title, url);
+
+        // then
+        assertThat(actual).isNotNull();
+    }
+
+    @Test
+    void 루트_탭_생성_시_마지막_위치_다음에_추가된다() {
+        // given
+        Long groupId = 1L;
+        String title = "새 루트 탭";
+        String url = "https://new-root.com";
+        TabTree beforeTree = tabService.getTabTree(groupId);
+        int beforeCount = beforeTree.getTotalCount();
+
+        // when
+        tabService.createRootTab(groupId, title, url);
+
+        // then
+        TabTree actual = tabService.getTabTree(groupId);
+        assertThat(actual.getTotalCount()).isEqualTo(beforeCount + 1);
+    }
+
+    @Test
+    void 자식_탭을_생성할_수_있다() {
+        // given
+        Long parentId = 100L;
+        String title = "새 자식 탭";
+        String url = "https://new-child.com";
+
+        // when
+        TabId actual = tabService.createChildTab(parentId, title, url);
+
+        // then
+        assertThat(actual).isNotNull();
+    }
+
+    @Test
+    void 자식_탭_생성_시_부모의_마지막_위치_다음에_추가된다() {
+        // given
+        Long parentId = 100L;
+        String title = "새 자식 탭";
+        String url = "https://new-child.com";
+        TabTree beforeTree = tabService.getTabTree(1L);
+        int beforeCount = beforeTree.getTotalCount();
+
+        // when
+        tabService.createChildTab(parentId, title, url);
+
+        // then
+        TabTree actual = tabService.getTabTree(1L);
+        assertThat(actual.getTotalCount()).isEqualTo(beforeCount + 1);
+    }
+
+    @Test
+    void 최대_깊이를_초과하면_자식_탭을_생성할_수_없다() {
+        // given
+        Long deepParentId = 112L;  // depth 9 탭 (MAX_DEPTH - 1)
+        String title = "깊은 자식 탭";
+        String url = "https://deep-child.com";
+
+        // when & then
+        assertThatThrownBy(() -> tabService.createChildTab(deepParentId, title, url))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 탭을_삭제할_수_있다() {
+        // given
+        Long tabId = 105L;
+
+        // when
+        tabService.deleteTab(tabId);
+
+        // then
+        TabTree actual = tabService.getTabTree(1L);
+        assertThat(actual.findNode(TabId.create(tabId))).isEmpty();
+    }
+
+    @Test
+    void 탭을_서브트리와_함께_삭제할_수_있다() {
+        // given
+        Long tabId = 101L;
+        TabTree beforeTree = tabService.getTabTree(1L);
+        int beforeCount = beforeTree.getTotalCount();
+
+        // when
+        tabService.deleteTabWithSubtree(tabId);
+
+        // then
+        TabTree actual = tabService.getTabTree(1L);
+        assertThat(actual.getTotalCount()).isLessThan(beforeCount);
+    }
+
+    @Test
+    void 서브트리와_함께_삭제하면_자손도_모두_삭제된다() {
+        // given
+        Long tabId = 101L;
+
+        // when
+        tabService.deleteTabWithSubtree(tabId);
+
+        // then
+        TabTree actual = tabService.getTabTree(1L);
+        assertAll(
+                () -> assertThat(actual.findNode(TabId.create(101L))).isEmpty(),
+                () -> assertThat(actual.findNode(TabId.create(103L))).isEmpty(),
+                () -> assertThat(actual.findNode(TabId.create(104L))).isEmpty()
+        );
+    }
+
+    @Test
+    void 탭을_루트로_이동할_수_있다() {
+        // given
+        Long tabId = 101L;
+
+        // when
+        tabService.moveRoot(tabId);
+
+        // then
+        TabTree actual = tabService.getTabTree(1L);
+        assertThat(actual.findNode(TabId.create(tabId)))
+                .isPresent()
+                .hasValueSatisfying(node -> assertThat(node.isRoot()).isTrue());
+    }
+
+    @Test
+    void 탭을_서브트리와_함께_루트로_이동할_수_있다() {
+        // given
+        Long tabId = 101L;
+
+        // when
+        tabService.moveRootWithSubtree(tabId);
+
+        // then
+        TabTree actual = tabService.getTabTree(1L);
+        assertThat(actual.findNode(TabId.create(tabId)))
+                .isPresent()
+                .hasValueSatisfying(node -> assertThat(node.isRoot()).isTrue());
+    }
+
+    @Test
+    void 탭을_다른_부모로_이동할_수_있다() {
+        // given
+        Long tabId = 103L;
+        Long newParentId = 102L;
+
+        // when
+        tabService.move(tabId, newParentId);
+
+        // then
+        TabTree actual = tabService.getTabTree(1L);
+        assertThat(actual.findNode(TabId.create(tabId)))
+                .isPresent()
+                .hasValueSatisfying(node -> assertThat(node.getParentId()).isEqualTo(TabId.create(newParentId)));
+    }
+
+    @Test
+    void 자기_자신을_부모로_이동할_수_없다() {
+        // given
+        Long tabId = 101L;
+        Long newParentId = 101L;
+
+        // when & then
+        assertThatThrownBy(() -> tabService.move(tabId, newParentId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("자기 자신을 부모로 설정할 수 없습니다.");
+    }
+
+    @Test
+    void 자손을_부모로_이동할_수_없다() {
+        // given
+        Long tabId = 101L;
+        Long newParentId = 103L;
+
+        // when & then
+        assertThatThrownBy(() -> tabService.move(tabId, newParentId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("순환 참조가 발생합니다: 자손을 부모로 설정할 수 없습니다.");
+    }
+
+    @Test
+    void 최대_깊이를_초과하면_이동할_수_없다() {
+        // given
+        Long tabId = 101L;
+        Long deepParentId = 112L;
+
+        // when & then
+        assertThatThrownBy(() -> tabService.move(tabId, deepParentId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("탭의 계층은 10를 초과할 수 없습니다.");
+    }
+
+    @Test
+    void 탭을_서브트리와_함께_이동할_수_있다() {
+        // given
+        Long tabId = 101L;
+        Long newParentId = 102L;
+
+        // when
+        tabService.moveWithSubtree(tabId, newParentId);
+
+        // then
+        TabTree actual = tabService.getTabTree(1L);
+        assertThat(actual.findNode(TabId.create(tabId)))
+                .isPresent()
+                .hasValueSatisfying(node -> assertThat(node.getParentId()).isEqualTo(TabId.create(newParentId)));
+    }
+
+    @Test
+    void 서브트리와_함께_이동하면_자손도_함께_이동한다() {
+        // given
+        Long tabId = 101L;
+        Long newParentId = 102L;
+
+        // when
+        tabService.moveWithSubtree(tabId, newParentId);
+
+        // then
+        TabTree actual = tabService.getTabTree(1L);
+        assertAll(
+                () -> assertThat(actual.findNode(TabId.create(103L))).isPresent(),
+                () -> assertThat(actual.findNode(TabId.create(104L))).isPresent()
+        );
+    }
+
+    @Test
+    void 서브트리와_함께_이동_시_최대_깊이를_초과하면_이동할_수_없다() {
+        // given
+        Long tabId = 101L;
+        Long deepParentId = 111L;
+
+        // when & then
+        assertThatThrownBy(() -> tabService.moveWithSubtree(tabId, deepParentId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("탭의 계층은 10를 초과할 수 없습니다.");
+    }
+
+    @Test
+    void 같은_레벨이_아닌_탭의_순서를_변경할_수_없다() {
+        // given
+        Long tabId = 101L;
+        Long targetTabId = 103L;
+
+        // when & then
+        assertThatThrownBy(() -> tabService.reorderTab(tabId, targetTabId, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("같은 레벨의 탭만 순서를 변경할 수 있습니다");
+    }
+
+    @Test
+    void 탭의_정보를_수정할_수_있다() {
+        // given
+        Long tabId = 100L;
+        String newTitle = "수정된 제목";
+        String newUrl = "https://updated.com";
+
+        // when
+        tabService.updateTab(tabId, newTitle, newUrl);
+
+        // then
+        TabTree actual = tabService.getTabTree(1L);
+        assertThat(actual.findNode(TabId.create(tabId)))
+                .isPresent()
+                .hasValueSatisfying(node -> assertAll(
+                        () -> assertThat(node.getTab().getTitle().getValue()).isEqualTo(newTitle),
+                        () -> assertThat(node.getTab().getUrl().getValue()).isEqualTo(newUrl)
+                ));
+    }
+
+    @Test
+    void 그룹의_탭_트리를_조회할_수_있다() {
+        // given
+        Long groupId = 1L;
+
+        // when
+        TabTree actual = tabService.getTabTree(groupId);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual.getTotalCount()).isGreaterThan(0)
+        );
+    }
+
+    @Test
+    void 루트_레벨_탭의_순서를_변경할_수_있다() {
+        // given
+        Long tabId = 100L;
+        Long targetTabId = 200L;
+
+        // when & then
+        assertDoesNotThrow(() -> tabService.reorderTab(tabId, targetTabId, true));
+    }
+
+    @Test
+    void 루트_탭과_일반_탭의_순서를_변경할_수_없다() {
+        // given
+        Long rootTabId = 100L;
+        Long childTabId = 101L;
+
+        // when & then
+        assertThatThrownBy(() -> tabService.reorderTab(rootTabId, childTabId, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("같은 레벨의 탭만 순서를 변경할 수 있습니다");
+    }
+
+    @Test
+    void 루트_레벨_탭_순서_변경_시_position이_업데이트된다() {
+        // given
+        Long tabId = 100L;
+        Long targetTabId = 200L;
+
+        // when
+        tabService.reorderTab(tabId, targetTabId, false);
+
+        // then
+        TabTree actual = tabService.getTabTree(1L);
+        assertThat(actual.findNode(TabId.create(tabId)))
+                .isPresent()
+                .hasValueSatisfying(node -> assertThat(node.getTab().getPosition().getValue()).isZero());
+    }
+}

--- a/src/test/java/com/management/tab/domain/common/AuditTimestampsTest.java
+++ b/src/test/java/com/management/tab/domain/common/AuditTimestampsTest.java
@@ -16,14 +16,31 @@ class AuditTimestampsTest {
     @Test
     void 생성시각과_수정시각이_같은_AuditTimestamps를_초기화한다() {
         // when
-        AuditTimestamps timestamps = AuditTimestamps.now();
+        AuditTimestamps actual = AuditTimestamps.now();
 
         // then
         assertAll(
-                () -> assertThat(timestamps).isNotNull(),
-                () -> assertThat(timestamps.getCreatedAt()).isNotNull(),
-                () -> assertThat(timestamps.getUpdatedAt()).isNotNull(),
-                () -> assertThat(timestamps.getCreatedAt()).isEqualTo(timestamps.getUpdatedAt())
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual.getCreatedAt()).isNotNull(),
+                () -> assertThat(actual.getUpdatedAt()).isNotNull(),
+                () -> assertThat(actual.getCreatedAt()).isEqualTo(actual.getUpdatedAt())
+        );
+    }
+
+    @Test
+    void 지정한_시각으로_AuditTimestamps를_생성할_수_있다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.of(2024, 1, 1, 10, 0);
+        LocalDateTime updatedAt = LocalDateTime.of(2024, 1, 2, 15, 30);
+
+        // when
+        AuditTimestamps actual = AuditTimestamps.create(createdAt, updatedAt);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual.getCreatedAt()).isEqualTo(createdAt),
+                () -> assertThat(actual.getUpdatedAt()).isEqualTo(updatedAt)
         );
     }
 
@@ -37,22 +54,23 @@ class AuditTimestampsTest {
         Thread.sleep(10);
 
         // when
-        AuditTimestamps updated = original.updateTimestamp();
+        AuditTimestamps actual = original.updateTimestamp();
 
         // then
         assertAll(
-                () -> assertThat(updated.getCreatedAt()).isEqualTo(originalCreatedAt),
-                () -> assertThat(updated.getUpdatedAt()).isAfter(originalUpdatedAt),
-                () -> assertThat(updated.getCreatedAt()).isBefore(updated.getUpdatedAt())
+                () -> assertThat(actual.getCreatedAt()).isEqualTo(originalCreatedAt),
+                () -> assertThat(actual.getUpdatedAt()).isAfter(originalUpdatedAt),
+                () -> assertThat(actual.getCreatedAt()).isBefore(actual.getUpdatedAt())
         );
     }
 
     @Test
     void 같은_시각을_가진_AuditTimestamps는_동등하다() {
         // given
-        AuditTimestamps timestamps1 = AuditTimestamps.now();
-
-        AuditTimestamps timestamps2 = timestamps1;
+        LocalDateTime createdAt = LocalDateTime.of(2024, 1, 1, 10, 0);
+        LocalDateTime updatedAt = LocalDateTime.of(2024, 1, 2, 15, 30);
+        AuditTimestamps timestamps1 = AuditTimestamps.create(createdAt, updatedAt);
+        AuditTimestamps timestamps2 = AuditTimestamps.create(createdAt, updatedAt);
 
         // when & then
         assertAll(
@@ -85,13 +103,12 @@ class AuditTimestampsTest {
         Thread.sleep(10);
 
         // when
-        AuditTimestamps updated = original.updateTimestamp();
+        AuditTimestamps actual = original.updateTimestamp();
 
         // then
         assertAll(
-                () -> assertThat(original).isNotEqualTo(updated),
-                () -> assertThat(original).doesNotHaveSameHashCodeAs(updated)
+                () -> assertThat(original).isNotEqualTo(actual),
+                () -> assertThat(original).doesNotHaveSameHashCodeAs(actual)
         );
     }
 }
-

--- a/src/test/java/com/management/tab/domain/group/TabGroupTest.java
+++ b/src/test/java/com/management/tab/domain/group/TabGroupTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -27,6 +29,28 @@ class TabGroupTest {
                 () -> assertThat(actual.getTimestamps()).isNotNull(),
                 () -> assertThat(actual.getTimestamps().getCreatedAt()).isNotNull(),
                 () -> assertThat(actual.getTimestamps().getUpdatedAt()).isNotNull()
+        );
+    }
+
+    @Test
+    void 지정한_시각과_ID로_TabGroup을_생성할_수_있다() {
+        // given
+        Long groupId = 100L;
+        String name = "테스트 그룹";
+        LocalDateTime createdAt = LocalDateTime.of(2024, 1, 1, 10, 0);
+        LocalDateTime updatedAt = LocalDateTime.of(2024, 1, 2, 15, 30);
+
+        // when
+        TabGroup actual = TabGroup.create(groupId, name, createdAt, updatedAt);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual.getId()).isNotNull(),
+                () -> assertThat(actual.getId().getValue()).isEqualTo(groupId),
+                () -> assertThat(actual.getName().getValue()).isEqualTo(name),
+                () -> assertThat(actual.getTimestamps().getCreatedAt()).isEqualTo(createdAt),
+                () -> assertThat(actual.getTimestamps().getUpdatedAt()).isEqualTo(updatedAt)
         );
     }
 
@@ -75,6 +99,41 @@ class TabGroupTest {
                 () -> assertThat(actual).isNotNull(),
                 () -> assertThat(actual.getName().getValue()).isEqualTo(newName),
                 () -> assertThat(actual.getTimestamps()).isEqualTo(tabGroup.getTimestamps())
+        );
+    }
+
+    @Test
+    void 이름_변경_시_ID는_유지된다() {
+        // given
+        TabGroup tabGroup = TabGroup.create(100L, "원래 이름",
+                LocalDateTime.now(), LocalDateTime.now());
+        String newName = "변경된 이름";
+
+        // when
+        TabGroup actual = tabGroup.rename(newName);
+
+        // then
+        assertAll(
+                () -> assertThat(actual.getId()).isNotNull(),
+                () -> assertThat(actual.getId()).isEqualTo(tabGroup.getId())
+        );
+    }
+
+    @Test
+    void 이름_변경_시_타임스탬프는_유지된다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.of(2024, 1, 1, 10, 0);
+        LocalDateTime updatedAt = LocalDateTime.of(2024, 1, 2, 15, 30);
+        TabGroup tabGroup = TabGroup.create(100L, "원래 이름", createdAt, updatedAt);
+        String newName = "변경된 이름";
+
+        // when
+        TabGroup actual = tabGroup.rename(newName);
+
+        // then
+        assertAll(
+                () -> assertThat(actual.getTimestamps().getCreatedAt()).isEqualTo(createdAt),
+                () -> assertThat(actual.getTimestamps().getUpdatedAt()).isEqualTo(updatedAt)
         );
     }
 }

--- a/src/test/java/com/management/tab/domain/tab/TabTest.java
+++ b/src/test/java/com/management/tab/domain/tab/TabTest.java
@@ -318,5 +318,22 @@ class TabTest {
         );
     }
 
+    @Test
+    void TabId로_같은_Tab인지_확인한다() {
+        // given
+        TabId tabId = TabId.create(1L);
+        TabId parentId = TabId.create(10L);
+        TabGroupId tabGroupId = TabGroupId.create(100L);
+        TabTitle title = TabTitle.create("테스트 탭");
+        TabUrl url = TabUrl.create("https://example.com");
+        TabPosition position = TabPosition.create(0);
+        AuditTimestamps timestamps = AuditTimestamps.now();
+        Tab tab = new Tab(tabId, parentId, tabGroupId, title, url, position, timestamps);
 
+        // when
+        boolean actual = tab.isEqualTo(tabId);
+
+        // then
+        assertThat(actual).isTrue();
+    }
 }

--- a/src/test/java/com/management/tab/persistence/JdbcTabGroupRepositoryTest.java
+++ b/src/test/java/com/management/tab/persistence/JdbcTabGroupRepositoryTest.java
@@ -1,0 +1,160 @@
+package com.management.tab.persistence;
+
+import com.management.tab.domain.group.TabGroup;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@Sql(scripts = {"classpath:sql/schema.sql", "classpath:sql/insert-jdbc-tab-group-repository-test-data.sql"})
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class JdbcTabGroupRepositoryTest {
+
+    @Autowired
+    JdbcTabGroupRepository jdbcTabGroupRepository;
+
+    @Test
+    void 모든_탭_그룹을_조회할_수_있다() {
+        // when
+        List<TabGroup> actual = jdbcTabGroupRepository.findAll();
+
+        // then
+        assertThat(actual).isNotEmpty();
+    }
+
+    @Test
+    void 조회한_탭_그룹_목록에_모든_그룹이_포함된다() {
+        // when
+        List<TabGroup> actual = jdbcTabGroupRepository.findAll();
+
+        // then
+        assertThat(actual).hasSizeGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    void ID로_탭_그룹을_조회할_수_있다() {
+        // given
+        Long groupId = 1L;
+
+        // when
+        TabGroup actual = jdbcTabGroupRepository.findById(groupId);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual.getId().getValue()).isEqualTo(groupId),
+                () -> assertThat(actual.getName().getValue()).isEqualTo("테스트 그룹1")
+        );
+    }
+
+    @Test
+    void 존재하지_않는_ID로_조회하면_예외가_발생한다() {
+        // given
+        Long groupId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> jdbcTabGroupRepository.findById(groupId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("지정한 ID에 해당하는 탭 그룹이 없습니다.");
+    }
+
+    @Test
+    void 탭_그룹을_저장할_수_있다() {
+        // given
+        TabGroup tabGroup = TabGroup.create("새 그룹");
+
+        // when
+        TabGroup actual = jdbcTabGroupRepository.save(tabGroup);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual.getId()).isNotNull(),
+                () -> assertThat(actual.getName().getValue()).isEqualTo("새 그룹")
+        );
+    }
+
+    @Test
+    void 탭_그룹의_이름을_변경할_수_있다() {
+        // given
+        Long groupId = 1L;
+        TabGroup tabGroup = jdbcTabGroupRepository.findById(groupId);
+        TabGroup renamedTabGroup = tabGroup.rename("변경된 그룹명");
+
+        // when
+        jdbcTabGroupRepository.updateRenamed(renamedTabGroup);
+
+        // then
+        TabGroup actual = jdbcTabGroupRepository.findById(groupId);
+
+        assertThat(actual.getName().getValue()).isEqualTo("변경된 그룹명");
+    }
+
+    @Test
+    void 이름_변경_시_ID는_유지된다() {
+        // given
+        Long groupId = 1L;
+        TabGroup tabGroup = jdbcTabGroupRepository.findById(groupId);
+        TabGroup renamedTabGroup = tabGroup.rename("변경된 그룹명");
+
+        // when
+        jdbcTabGroupRepository.updateRenamed(renamedTabGroup);
+
+        // then
+        TabGroup actual = jdbcTabGroupRepository.findById(groupId);
+
+        assertThat(actual.getId().getValue()).isEqualTo(groupId);
+    }
+
+    @Test
+    void 탭_그룹을_삭제할_수_있다() {
+        // given
+        TabGroup tabGroup = TabGroup.create("삭제할 그룹");
+        TabGroup saved = jdbcTabGroupRepository.save(tabGroup);
+        Long groupId = saved.getId().getValue();
+
+        // when
+        jdbcTabGroupRepository.delete(groupId);
+
+        // then
+        assertThatThrownBy(() -> jdbcTabGroupRepository.findById(groupId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("지정한 ID에 해당하는 탭 그룹이 없습니다.");
+    }
+
+    @Test
+    void 탭이_없는_그룹의_탭_개수는_0이다() {
+        // given
+        TabGroup tabGroup = TabGroup.create("빈 그룹");
+        TabGroup saved = jdbcTabGroupRepository.save(tabGroup);
+        Long groupId = saved.getId().getValue();
+
+        // when
+        int actual = jdbcTabGroupRepository.countTabs(groupId);
+
+        // then
+        assertThat(actual).isZero();
+    }
+
+    @Test
+    void 탭이_있는_그룹의_탭_개수를_조회한다() {
+        // given
+        Long groupId = 1L;
+
+        // when
+        int actual = jdbcTabGroupRepository.countTabs(groupId);
+
+        // then
+        assertThat(actual).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/management/tab/persistence/JdbcTabRepositoryTest.java
+++ b/src/test/java/com/management/tab/persistence/JdbcTabRepositoryTest.java
@@ -1,0 +1,350 @@
+package com.management.tab.persistence;
+
+import com.management.tab.domain.group.vo.TabGroupId;
+import com.management.tab.domain.tab.Tab;
+import com.management.tab.domain.tab.TabBuilder;
+import com.management.tab.domain.tab.TabTree;
+import com.management.tab.domain.tab.vo.TabId;
+import com.management.tab.domain.tab.vo.TabPosition;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@Sql(scripts = {"classpath:sql/schema.sql", "classpath:sql/insert-jdbc-tab-repository-test-data.sql"})
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class JdbcTabRepositoryTest {
+
+    @Autowired
+    private JdbcTabRepository jdbcTabRepository;
+
+    @Test
+    void 루트_탭을_저장할_수_있다() {
+        // given
+        Tab rootTab = TabBuilder.createRoot(1L, "새 루트 탭", "https://new-root.com", TabPosition.create(10))
+                                .build();
+
+        // when
+        Tab actual = jdbcTabRepository.saveRoot(rootTab);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual.getId()).isNotNull(),
+                () -> assertThat(actual.getTitle().getValue()).isEqualTo("새 루트 탭"),
+                () -> assertThat(actual.getUrl().getValue()).isEqualTo("https://new-root.com"),
+                () -> assertThat(actual.getPosition().getValue()).isEqualTo(10),
+                () -> assertThat(actual.isRoot()).isTrue()
+        );
+    }
+
+    @Test
+    void 자식_탭을_저장할_수_있다() {
+        // given
+        Tab parentTab = jdbcTabRepository.findTab(100L);
+        Tab childTab = TabBuilder.createChild(parentTab, "새 자식 탭", "https://new-child.com", TabPosition.create(5))
+                                 .build();
+
+        // when
+        Tab actual = jdbcTabRepository.saveChild(childTab);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual.getId()).isNotNull(),
+                () -> assertThat(actual.getTitle().getValue()).isEqualTo("새 자식 탭"),
+                () -> assertThat(actual.getUrl().getValue()).isEqualTo("https://new-child.com"),
+                () -> assertThat(actual.getParentId().getValue()).isEqualTo(100L),
+                () -> assertThat(actual.isRoot()).isFalse()
+        );
+    }
+
+    @Test
+    void ID로_탭을_조회할_수_있다() {
+        // given
+        Long tabId = 100L;
+
+        // when
+        Tab actual = jdbcTabRepository.findTab(tabId);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual.getId().getValue()).isEqualTo(100L),
+                () -> assertThat(actual.getTitle().getValue()).isEqualTo("루트_탭1")
+        );
+    }
+
+    @Test
+    void 존재하지_않는_ID로_조회하면_예외가_발생한다() {
+        // given
+        Long tabId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> jdbcTabRepository.findTab(tabId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("지정한 탭을 찾을 수 없습니다.");
+    }
+
+    @Test
+    void 그룹의_탭_트리를_조회할_수_있다() {
+        // given
+        TabGroupId groupId = TabGroupId.create(1L);
+
+        // when
+        TabTree actual = jdbcTabRepository.findTabTree(groupId);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual.getTabGroupId()).isEqualTo(groupId),
+                () -> assertThat(actual.getTotalCount()).isEqualTo(6)
+        );
+    }
+
+    @Test
+    void 탭의_부모_ID를_조회할_수_있다() {
+        // given
+        Long tabId = 101L;
+
+        // when
+        TabId actual = jdbcTabRepository.findParentId(tabId);
+
+        // then
+        assertThat(actual.getValue()).isEqualTo(100L);
+    }
+
+    @Test
+    void 루트_탭의_부모_ID를_조회하면_예외가_발생한다() {
+        // given
+        Long rootTabId = 100L;
+
+        // when & then
+        assertThatThrownBy(() -> jdbcTabRepository.findParentId(rootTabId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("부모 ID가 없습니다.");
+    }
+
+    @Test
+    void 그룹의_마지막_루트_탭_위치를_조회할_수_있다() {
+        // given
+        Long groupId = 1L;
+
+        // when
+        TabPosition actual = jdbcTabRepository.findLastRootPosition(groupId);
+
+        // then
+        assertThat(actual.getValue()).isZero();
+    }
+
+    @Test
+    void 특정_부모의_형제_탭들을_조회할_수_있다() {
+        // given
+        TabId parentId = TabId.create(100L);
+
+        // when
+        List<Tab> actual = jdbcTabRepository.findSiblings(parentId);
+
+        // then
+        assertThat(actual).hasSize(2);
+    }
+
+    @Test
+    void 형제_탭_조회_시_모두_같은_부모를_가진다() {
+        // given
+        TabId parentId = TabId.create(100L);
+
+        // when
+        List<Tab> actual = jdbcTabRepository.findSiblings(parentId);
+
+        // then
+        assertThat(actual).isNotEmpty()
+                          .allMatch(tab -> tab.getParentId().getValue().equals(100L));
+    }
+
+    @Test
+    void 루트_레벨_형제들을_조회할_수_있다() {
+        // when
+        List<Tab> actual = jdbcTabRepository.findRootSiblings();
+
+        // then
+        assertThat(actual).isNotEmpty();
+    }
+
+    @Test
+    void 루트_레벨_형제_조회_시_모두_루트_탭이다() {
+        // when
+        List<Tab> actual = jdbcTabRepository.findRootSiblings();
+
+        // then
+        assertThat(actual).isNotEmpty()
+                          .allMatch(Tab::isRoot);
+    }
+
+    @Test
+    void 탭을_다른_부모로_이동할_수_있다() {
+        // given
+        Tab tab = jdbcTabRepository.findTab(103L);
+        TabId currentParentId = TabId.create(101L);
+        Tab movedTab = tab.moveTo(TabId.create(102L), TabPosition.create(0));
+
+        // when
+        jdbcTabRepository.updateMoved(movedTab, currentParentId);
+
+        // then
+        Tab actual = jdbcTabRepository.findTab(103L);
+        assertThat(actual.getParentId().getValue()).isEqualTo(102L);
+    }
+
+    @Test
+    void 탭을_서브트리와_함께_이동할_수_있다() {
+        // given
+        Tab tab = jdbcTabRepository.findTab(101L);
+        Tab movedTab = tab.moveTo(TabId.create(102L), TabPosition.create(0));
+
+        // when
+        jdbcTabRepository.updateMovedTabWithSubtree(movedTab);
+
+        // then
+        Tab actual = jdbcTabRepository.findTab(101L);
+        assertThat(actual.getParentId().getValue()).isEqualTo(102L);
+    }
+
+    @Test
+    void 탭을_루트로_이동할_수_있다() {
+        // given
+        Tab tab = jdbcTabRepository.findTab(101L);
+        TabId currentParentId = TabId.create(100L);
+        Tab movedTab = tab.moveToRoot(TabPosition.create(1));
+
+        // when
+        jdbcTabRepository.updateMovedRoot(movedTab, currentParentId);
+
+        // then
+        Tab actual = jdbcTabRepository.findTab(101L);
+
+        assertAll(
+                () -> assertThat(actual.getParentId()).isNull(),
+                () -> assertThat(actual.isRoot()).isTrue()
+        );
+    }
+
+    @Test
+    void 탭을_서브트리와_함께_루트로_이동할_수_있다() {
+        // given
+        Tab tab = jdbcTabRepository.findTab(101L);
+        Tab movedTab = tab.moveToRoot(TabPosition.create(1));
+
+        // when
+        jdbcTabRepository.updateMovedRootWithSubtree(movedTab);
+
+        // then
+        Tab actual = jdbcTabRepository.findTab(101L);
+        assertThat(actual.getParentId()).isNull();
+    }
+
+    @Test
+    void 탭의_위치를_변경할_수_있다() {
+        // given
+        TabId tabId = TabId.create(101L);
+        TabPosition newPosition = TabPosition.create(10);
+
+        // when
+        jdbcTabRepository.updatePosition(tabId, newPosition);
+
+        // then
+        Tab actual = jdbcTabRepository.findTab(101L);
+        assertThat(actual.getPosition().getValue()).isEqualTo(10);
+    }
+
+    @Test
+    void 탭의_정보를_수정할_수_있다() {
+        // given
+        Tab tab = jdbcTabRepository.findTab(100L);
+        Tab updatedTab = tab.updateInfo("수정된 제목", "https://updated.com");
+
+        // when
+        jdbcTabRepository.updateTabInfo(updatedTab);
+
+        // then
+        Tab actual = jdbcTabRepository.findTab(100L);
+        assertAll(
+                () -> assertThat(actual.getTitle().getValue()).isEqualTo("수정된 제목"),
+                () -> assertThat(actual.getUrl().getValue()).isEqualTo("https://updated.com")
+        );
+    }
+
+    @Test
+    void 탭을_서브트리와_함께_삭제할_수_있다() {
+        // given
+        Tab tab = jdbcTabRepository.findTab(101L);
+        TabTree beforeTree = jdbcTabRepository.findTabTree(TabGroupId.create(1L));
+        int beforeCount = beforeTree.getTotalCount();
+
+        // when
+        jdbcTabRepository.deleteTabWithSubtree(tab);
+
+        // then
+        TabTree actual = jdbcTabRepository.findTabTree(TabGroupId.create(1L));
+        assertThat(actual.getTotalCount()).isLessThan(beforeCount);
+    }
+
+    @Test
+    void 탭을_서브트리와_함께_삭제하면_해당_탭의_자손도_모두_삭제된다() {
+        // given
+        Tab tab = jdbcTabRepository.findTab(101L);
+
+        // when
+        jdbcTabRepository.deleteTabWithSubtree(tab);
+
+        // then
+        assertAll(
+                () -> assertThatThrownBy(() -> jdbcTabRepository.findTab(101L))
+                        .isInstanceOf(IllegalArgumentException.class),
+                () -> assertThatThrownBy(() -> jdbcTabRepository.findTab(103L))
+                        .isInstanceOf(IllegalArgumentException.class),
+                () -> assertThatThrownBy(() -> jdbcTabRepository.findTab(104L))
+                        .isInstanceOf(IllegalArgumentException.class)
+        );
+    }
+
+    @Test
+    void 해당_탭만_삭제할_수_있다() {
+        // given
+        Tab tab = jdbcTabRepository.findTab(105L);
+
+        // when
+        jdbcTabRepository.deleteTab(tab);
+
+        // then
+        assertThatThrownBy(() -> jdbcTabRepository.findTab(105L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("지정한 탭을 찾을 수 없습니다.");
+    }
+
+    @Test
+    void 해당_탭만_삭제하면_자식은_유지된다() {
+        // given
+        Tab tab = jdbcTabRepository.findTab(102L);
+
+        // when
+        jdbcTabRepository.deleteTab(tab);
+
+        // then
+        assertAll(
+                () -> assertThatThrownBy(() -> jdbcTabRepository.findTab(102L))
+                        .isInstanceOf(IllegalArgumentException.class),
+                () -> jdbcTabRepository.findTab(105L)
+        );
+    }
+}

--- a/src/test/java/com/management/tab/persistence/JdbcTabRepositoryTest.java
+++ b/src/test/java/com/management/tab/persistence/JdbcTabRepositoryTest.java
@@ -125,14 +125,15 @@ class JdbcTabRepositoryTest {
     }
 
     @Test
-    void 루트_탭의_부모_ID를_조회하면_예외가_발생한다() {
+    void 루트_탭의_부모_ID를_조회하면_null을_반환한다() {
         // given
         Long rootTabId = 100L;
 
-        // when & then
-        assertThatThrownBy(() -> jdbcTabRepository.findParentId(rootTabId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("부모 ID가 없습니다.");
+        // when
+        TabId actual = jdbcTabRepository.findParentId(rootTabId);
+
+        // then
+        assertThat(actual).isNull();
     }
 
     @Test

--- a/src/test/java/com/management/tab/persistence/dao/InsertTabDaoTest.java
+++ b/src/test/java/com/management/tab/persistence/dao/InsertTabDaoTest.java
@@ -154,7 +154,7 @@ class InsertTabDaoTest {
         insertTabDao.saveRootTab(groupId, "세번째", "http://3.com", 2, now, now);
 
         // then
-        List<TabDto> actual = selectTabDao.findSiblings(null);
+        List<TabDto> actual = selectTabDao.findRootSiblings();
         assertAll(
                 () -> assertThat(actual).hasSize(4),
                 () -> assertThat(actual.stream().filter(t -> t.position() == 0).count()).isEqualTo(2),

--- a/src/test/java/com/management/tab/persistence/dao/SelectTabDaoTest.java
+++ b/src/test/java/com/management/tab/persistence/dao/SelectTabDaoTest.java
@@ -164,15 +164,24 @@ class SelectTabDaoTest {
     }
 
     @Test
-    void 루트_레벨_형제들을_조회한다() {
+    void 부모가_null인_경우_빈_리스트를_반환한다() {
         // when
         List<TabDto> actual = selectTabDao.findSiblings(null);
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void 루트_레벨_형제들을_조회한다() {
+        // when
+        List<TabDto> actual = selectTabDao.findRootSiblings();
 
         // then
         assertThat(actual.stream()
                          .filter(t -> GROUP_ID.equals(t.groupId()))
                          .count())
-                .isEqualTo(2);
+                .isGreaterThanOrEqualTo(1);
     }
 
     @Test
@@ -209,6 +218,15 @@ class SelectTabDaoTest {
 
         // then
         assertThat(actual).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void 탭이_없는_그룹의_루트_position을_조회하면_0을_반환한다() {
+        // when
+        int actual = selectTabDao.findRootTabLastPosition(999L);
+
+        // then
+        assertThat(actual).isZero();
     }
 
     @Test

--- a/src/test/resources/sql/delete-tab-test-data.sql
+++ b/src/test/resources/sql/delete-tab-test-data.sql
@@ -29,7 +29,6 @@ VALUES
     (204, 1, 201, '삭제테스트_손자2', 'http://gc2.com', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
     (205, 1, 202, '삭제테스트_손자3', 'http://gc3.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
--- Closure Table 경로 생성
 -- 200 (루트)
 INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth) VALUES (200, 200, 0);
 

--- a/src/test/resources/sql/insert-jdbc-tab-group-repository-test-data.sql
+++ b/src/test/resources/sql/insert-jdbc-tab-group-repository-test-data.sql
@@ -1,0 +1,19 @@
+-- 탭 그룹 초기화
+INSERT INTO tab_groups (id, name, created_at, updated_at)
+VALUES
+    (1, '테스트 그룹1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (2, '테스트 그룹2', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- 그룹1에 탭 추가 (countTabs 테스트용)
+INSERT INTO tabs (id, group_id, parent_id, title, url, position, created_at, updated_at)
+VALUES
+    (100, 1, NULL, '그룹1_루트탭', 'https://root.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- Closure Table 경로
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (100, 100, 0);
+
+-- H2 시퀀스 리셋
+ALTER TABLE tab_groups ALTER COLUMN id RESTART WITH 3;
+ALTER TABLE tabs ALTER COLUMN id RESTART WITH 101;

--- a/src/test/resources/sql/insert-jdbc-tab-repository-test-data.sql
+++ b/src/test/resources/sql/insert-jdbc-tab-repository-test-data.sql
@@ -1,0 +1,74 @@
+-- 탭 그룹 생성
+INSERT INTO tab_groups (id, name, created_at, updated_at)
+VALUES
+    (1, 'JdbcTabRepository 테스트 그룹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- 테스트용 트리 구조
+-- 구조:
+-- 100 (루트)
+--   ├─ 101 (자식1)
+--   │   ├─ 103 (손자1)
+--   │   └─ 104 (손자2)
+--   └─ 102 (자식2)
+--       └─ 105 (손자3)
+
+-- 루트 탭
+INSERT INTO tabs (id, group_id, parent_id, title, url, position, created_at, updated_at)
+VALUES
+    (100, 1, NULL, '루트_탭1', 'https://root1.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- 자식 탭
+INSERT INTO tabs (id, group_id, parent_id, title, url, position, created_at, updated_at)
+VALUES
+    (101, 1, 100, '자식_탭1', 'https://child1.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (102, 1, 100, '자식_탭2', 'https://child2.com', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- 손자 탭
+INSERT INTO tabs (id, group_id, parent_id, title, url, position, created_at, updated_at)
+VALUES
+    (103, 1, 101, '손자_탭1', 'https://grandchild1.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (104, 1, 101, '손자_탭2', 'https://grandchild2.com', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (105, 1, 102, '손자_탭3', 'https://grandchild3.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- Closure Table 경로 생성
+-- 100 (루트)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (100, 100, 0);
+
+-- 101 (자식1)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (101, 101, 0),
+    (100, 101, 1);
+
+-- 102 (자식2)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (102, 102, 0),
+    (100, 102, 1);
+
+-- 103 (손자1)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (103, 103, 0),
+    (101, 103, 1),
+    (100, 103, 2);
+
+-- 104 (손자2)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (104, 104, 0),
+    (101, 104, 1),
+    (100, 104, 2);
+
+-- 105 (손자3)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (105, 105, 0),
+    (102, 105, 1),
+    (100, 105, 2);
+
+-- ID SEQUENCE 초기화
+ALTER TABLE tab_groups ALTER COLUMN id RESTART WITH 2;
+ALTER TABLE tabs ALTER COLUMN id RESTART WITH 106;

--- a/src/test/resources/sql/insert-tab-group-service-test-data.sql
+++ b/src/test/resources/sql/insert-tab-group-service-test-data.sql
@@ -1,0 +1,75 @@
+-- 탭 그룹 생성
+INSERT INTO tab_groups (id, name, created_at, updated_at)
+VALUES
+    (1, '테스트 그룹1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (2, '테스트 그룹2', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- 테스트용 트리 구조 (그룹 1)
+-- 구조:
+-- 100 (루트)
+--   ├─ 101 (자식1)
+--   │   ├─ 103 (손자1)
+--   │   └─ 104 (손자2)
+--   └─ 102 (자식2)
+--       └─ 105 (손자3)
+
+-- 루트 탭
+INSERT INTO tabs (id, group_id, parent_id, title, url, position, created_at, updated_at)
+VALUES
+    (100, 1, NULL, '루트_탭1', 'https://root1.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- 자식 탭
+INSERT INTO tabs (id, group_id, parent_id, title, url, position, created_at, updated_at)
+VALUES
+    (101, 1, 100, '자식_탭1', 'https://child1.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (102, 1, 100, '자식_탭2', 'https://child2.com', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- 손자 탭
+INSERT INTO tabs (id, group_id, parent_id, title, url, position, created_at, updated_at)
+VALUES
+    (103, 1, 101, '손자_탭1', 'https://grandchild1.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (104, 1, 101, '손자_탭2', 'https://grandchild2.com', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (105, 1, 102, '손자_탭3', 'https://grandchild3.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- Closure Table 경로 생성
+-- 100 (루트)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (100, 100, 0);
+
+-- 101 (자식1)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (101, 101, 0),
+    (100, 101, 1);
+
+-- 102 (자식2)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (102, 102, 0),
+    (100, 102, 1);
+
+-- 103 (손자1)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (103, 103, 0),
+    (101, 103, 1),
+    (100, 103, 2);
+
+-- 104 (손자2)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (104, 104, 0),
+    (101, 104, 1),
+    (100, 104, 2);
+
+-- 105 (손자3)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (105, 105, 0),
+    (102, 105, 1),
+    (100, 105, 2);
+
+-- ID SEQUENCE 초기화
+ALTER TABLE tab_groups ALTER COLUMN id RESTART WITH 3;
+ALTER TABLE tabs ALTER COLUMN id RESTART WITH 106;

--- a/src/test/resources/sql/insert-tab-service-test-data.sql
+++ b/src/test/resources/sql/insert-tab-service-test-data.sql
@@ -1,0 +1,117 @@
+-- 탭 그룹 생성
+INSERT INTO tab_groups (id, name, created_at, updated_at)
+VALUES
+    (1, 'TabService 테스트 그룹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- 테스트용 트리 구조
+-- 구조:
+-- 100 (루트1, depth 0)
+--   ├─ 101 (자식1, depth 1)
+--   │   ├─ 103 (손자1, depth 2)
+--   │   └─ 104 (손자2, depth 2)
+--   └─ 102 (자식2, depth 1)
+--       └─ 105 (손자3, depth 2)
+--           └─ 106 (증손자1, depth 3)
+--               └─ 107 (고손자1, depth 4)
+--                   └─ 108 (5대손, depth 5)
+--                       └─ 109 (6대손, depth 6)
+--                           └─ 110 (7대손, depth 7)
+--                               └─ 111 (8대손, depth 8)
+--                                   └─ 112 (9대손, depth 9)
+-- 200 (루트2, depth 0)
+-- 300 (루트3, depth 0)
+
+-- 루트 탭
+INSERT INTO tabs (id, group_id, parent_id, title, url, position, created_at, updated_at)
+VALUES
+    (100, 1, NULL, '루트_탭1', 'https://root1.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (200, 1, NULL, '루트_탭2', 'https://root2.com', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (300, 1, NULL, '루트_탭3', 'https://root3.com', 2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- depth 1
+INSERT INTO tabs (id, group_id, parent_id, title, url, position, created_at, updated_at)
+VALUES
+    (101, 1, 100, '자식_탭1', 'https://child1.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (102, 1, 100, '자식_탭2', 'https://child2.com', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- depth 2
+INSERT INTO tabs (id, group_id, parent_id, title, url, position, created_at, updated_at)
+VALUES
+    (103, 1, 101, '손자_탭1', 'https://grandchild1.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (104, 1, 101, '손자_탭2', 'https://grandchild2.com', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (105, 1, 102, '손자_탭3', 'https://grandchild3.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- depth 3-9 (깊이 테스트용)
+INSERT INTO tabs (id, group_id, parent_id, title, url, position, created_at, updated_at)
+VALUES
+    (106, 1, 105, '증손자_탭1', 'https://depth3.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (107, 1, 106, '고손자_탭1', 'https://depth4.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (108, 1, 107, 'depth5_탭', 'https://depth5.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (109, 1, 108, 'depth6_탭', 'https://depth6.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (110, 1, 109, 'depth7_탭', 'https://depth7.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (111, 1, 110, 'depth8_탭', 'https://depth8.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (112, 1, 111, 'depth9_탭', 'https://depth9.com', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- Closure Table 경로 생성
+-- 100 (루트1)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (100, 100, 0);
+
+-- 200 (루트2)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (200, 200, 0);
+
+-- 300 (루트3)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (300, 300, 0);
+
+-- 101 (자식1)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (101, 101, 0),
+    (100, 101, 1);
+
+-- 102 (자식2)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (102, 102, 0),
+    (100, 102, 1);
+
+-- 103 (손자1)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (103, 103, 0),
+    (101, 103, 1),
+    (100, 103, 2);
+
+-- 104 (손자2)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (104, 104, 0),
+    (101, 104, 1),
+    (100, 104, 2);
+
+-- 105 (손자3)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (105, 105, 0),
+    (102, 105, 1),
+    (100, 105, 2);
+
+-- 106-112 (depth 3-9)
+INSERT INTO tab_tree_paths (ancestor_id, descendant_id, depth)
+VALUES
+    (106, 106, 0), (105, 106, 1), (102, 106, 2), (100, 106, 3),
+    (107, 107, 0), (106, 107, 1), (105, 107, 2), (102, 107, 3), (100, 107, 4),
+    (108, 108, 0), (107, 108, 1), (106, 108, 2), (105, 108, 3), (102, 108, 4), (100, 108, 5),
+    (109, 109, 0), (108, 109, 1), (107, 109, 2), (106, 109, 3), (105, 109, 4), (102, 109, 5), (100, 109, 6),
+    (110, 110, 0), (109, 110, 1), (108, 110, 2), (107, 110, 3), (106, 110, 4), (105, 110, 5), (102, 110, 6), (100, 110, 7),
+    (111, 111, 0), (110, 111, 1), (109, 111, 2), (108, 111, 3), (107, 111, 4), (106, 111, 5), (105, 111, 6), (102, 111, 7), (100, 111, 8),
+    (112, 112, 0), (111, 112, 1), (110, 112, 2), (109, 112, 3), (108, 112, 4), (107, 112, 5), (106, 112, 6), (105, 112, 7), (102, 112, 8), (100, 112, 9);
+
+-- H2 시퀀스 리셋
+ALTER TABLE tab_groups ALTER COLUMN id RESTART WITH 2;
+ALTER TABLE tabs ALTER COLUMN id RESTART WITH 301;


### PR DESCRIPTION
# 관련 이슈 

- closed #9 

# 작업 요약

- 리포지토리, 서비스 기능 추가
- 일부 도메인 기능 추가 및 리팩터링
 
# Task

- feat
  - Tab 관련 Repository 추가 
  - Tab 관련 Service 추가 
  - TabGroup 관련 Repository 추가 
  - TabGroup 관련 Service 추가
- etc
  - 불필요한 주석 삭제 
  - 탭의 형제 조회 시 루트 / 그 외의 경우로 분리 
  - Tab TabId로만 동등성 비교 로직 추가 
  - 부모 탭 ID 조회 시 자기 자신이 Root인지를 고려하도록 변경